### PR TITLE
Finite diff for sirf

### DIFF
--- a/Wrappers/Python/ccpi/framework/BlockDataContainer.py
+++ b/Wrappers/Python/ccpi/framework/BlockDataContainer.py
@@ -184,7 +184,7 @@ class BlockDataContainer(object):
         if not self.is_compatible(other):
             raise ValueError('Incompatible for divide')
         out = kwargs.get('out', None)
-        if isinstance(other, Number) or issubclass(other.__class__, DataContainer):
+        if isinstance(other, Number):
             # try to do algebra with one DataContainer. Will raise error if not compatible
             kw = kwargs.copy()
             res = []
@@ -243,8 +243,7 @@ class BlockDataContainer(object):
             else:
                 return type(self)(*res, shape=self.shape)
             return type(self)(*[ operation(ot, *args, **kwargs) for el,ot in zip(self.containers,other)], shape=self.shape)
-        elif has_sirf and ( isinstance(other, Number) or \
-                issubclass(other.__class__, SIRFDataContainer ) ) :
+        else:
             # try to do algebra with one DataContainer. Will raise error if not compatible
             kw = kwargs.copy()
             res = []
@@ -270,9 +269,7 @@ class BlockDataContainer(object):
                 return
             else:
                 return type(self)(*res, shape=self.shape)
-        else:
-            raise ValueError('Incompatible type {}'.format(type(other)))
-    
+        
 
     def power(self, other, *args, **kwargs):
         if not self.is_compatible(other):

--- a/Wrappers/Python/ccpi/framework/BlockDataContainer.py
+++ b/Wrappers/Python/ccpi/framework/BlockDataContainer.py
@@ -127,11 +127,12 @@ class BlockDataContainer(object):
                     a = el.shape == other.shape
                 ret = ret and a
             return ret
+        elif isinstance(other, BlockDataContainer): 
+            return len(self.containers) == len(other.containers)
 
         else:
             raise TypeError('Unsupported type. Expected number, numpy array, CIL DataContainer and subclass or SIRF DataContainer and subclasses. Got {}'. format(type(other)))
             #return self.get_item(0).shape == other.shape
-        return len(self.containers) == len(other.containers)
 
     def get_item(self, row):
         if row > self.shape[0]:

--- a/Wrappers/Python/ccpi/framework/BlockDataContainer.py
+++ b/Wrappers/Python/ccpi/framework/BlockDataContainer.py
@@ -27,13 +27,7 @@ from ccpi.framework import DataContainer
 #from ccpi.framework import AcquisitionData, ImageData
 #from ccpi.optimisation.operators import Operator, LinearOperator
 
-try:
-    from sirf import SIRF
-    from sirf.SIRF import DataContainer as SIRFDataContainer
-    has_sirf = True
-except ImportError as ie:
-    has_sirf = False
- 
+
 class BlockDataContainer(object):
     '''Class to hold DataContainers as column vector
     
@@ -109,32 +103,20 @@ class BlockDataContainer(object):
                     raise ValueError('List/ numpy array can only contain numbers {}'\
                                      .format(type(ot)))
             return len(self.containers) == len(other)
-        elif issubclass(other.__class__, DataContainer):
-            ret = True
-            for i, el in enumerate(self.containers):
-                if isinstance(el, BlockDataContainer):
-                    a = el.is_compatible(other)
-                else:
-                    a = el.shape == other.shape
-                ret = ret and a
-            return ret
-        elif has_sirf and \
-                issubclass(other.__class__, SIRFDataContainer ):
-            # test as above
-            ret = True
-            for i, el in enumerate(self.containers):
-                if isinstance(el, BlockDataContainer):
-                    a = el.is_compatible(other)
-                else:
-                    a = el.shape == other.shape
-                ret = ret and a
-            return ret
         elif isinstance(other, BlockDataContainer): 
             return len(self.containers) == len(other.containers)
-
         else:
-            raise TypeError('Unsupported type. Expected number, numpy array, CIL DataContainer and subclass or SIRF DataContainer and subclasses. Got {}'. format(type(other)))
-            #return self.get_item(0).shape == other.shape
+            # this should work for other as DataContainers and children
+            ret = True
+            for i, el in enumerate(self.containers):
+                if isinstance(el, BlockDataContainer):
+                    a = el.is_compatible(other)
+                else:
+                    a = el.shape == other.shape
+                ret = ret and a
+            # probably will raise 
+            return ret
+
 
     def get_item(self, row):
         if row > self.shape[0]:

--- a/Wrappers/Python/ccpi/framework/BlockDataContainer.py
+++ b/Wrappers/Python/ccpi/framework/BlockDataContainer.py
@@ -26,6 +26,12 @@ import functools
 from ccpi.framework import DataContainer
 #from ccpi.framework import AcquisitionData, ImageData
 #from ccpi.optimisation.operators import Operator, LinearOperator
+
+try:
+    from sirf import DataContainer as SIRFDataContainer
+    has_sirf = True
+except ImportError as ie:
+    has_sirf = False
  
 class BlockDataContainer(object):
     '''Class to hold DataContainers as column vector
@@ -111,6 +117,19 @@ class BlockDataContainer(object):
                     a = el.shape == other.shape
                 ret = ret and a
             return ret
+        elif has_sirf and issubclass(other.__class__, SIRFDataContainer):
+            # test as above
+            ret = True
+            for i, el in enumerate(self.containers):
+                if isinstance(el, BlockDataContainer):
+                    a = el.is_compatible(other)
+                else:
+                    a = el.shape == other.shape
+                ret = ret and a
+            return ret
+
+        else:
+            raise TypeError('Unsupported type. Expected number, numpy array, CIL DataContainer and subclass or SIRF DataContainer and subclasses. Got {}'. format(type(other)))
             #return self.get_item(0).shape == other.shape
         return len(self.containers) == len(other.containers)
 

--- a/Wrappers/Python/ccpi/framework/TestData.py
+++ b/Wrappers/Python/ccpi/framework/TestData.py
@@ -15,6 +15,7 @@
 #   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
+from __future__ import division
 from ccpi.framework import ImageData, ImageGeometry, DataContainer
 import numpy
 import numpy as np

--- a/Wrappers/Python/ccpi/framework/TestData.py
+++ b/Wrappers/Python/ccpi/framework/TestData.py
@@ -15,7 +15,11 @@
 #   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
+from __future__ import absolute_import
 from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 from ccpi.framework import ImageData, ImageGeometry, DataContainer
 import numpy
 import numpy as np

--- a/Wrappers/Python/ccpi/optimisation/algorithms/CGLS.py
+++ b/Wrappers/Python/ccpi/optimisation/algorithms/CGLS.py
@@ -17,6 +17,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 from ccpi.optimisation.algorithms import Algorithm
 import numpy
 

--- a/Wrappers/Python/ccpi/optimisation/algorithms/FISTA.py
+++ b/Wrappers/Python/ccpi/optimisation/algorithms/FISTA.py
@@ -17,6 +17,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 from ccpi.optimisation.algorithms import Algorithm
 from ccpi.optimisation.functions import ZeroFunction
 import numpy

--- a/Wrappers/Python/ccpi/optimisation/algorithms/GradientDescent.py
+++ b/Wrappers/Python/ccpi/optimisation/algorithms/GradientDescent.py
@@ -20,6 +20,11 @@
 #
 #=========================================================================
 
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 from ccpi.optimisation.algorithms import Algorithm
 
 class GradientDescent(Algorithm):

--- a/Wrappers/Python/ccpi/optimisation/algorithms/PDHG.py
+++ b/Wrappers/Python/ccpi/optimisation/algorithms/PDHG.py
@@ -17,6 +17,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 from ccpi.optimisation.algorithms import Algorithm
 
 

--- a/Wrappers/Python/ccpi/optimisation/algorithms/SIRT.py
+++ b/Wrappers/Python/ccpi/optimisation/algorithms/SIRT.py
@@ -20,6 +20,11 @@
 #
 #=========================================================================
 
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 from ccpi.optimisation.algorithms import Algorithm
 
 class SIRT(Algorithm):

--- a/Wrappers/Python/ccpi/optimisation/functions/BlockFunction.py
+++ b/Wrappers/Python/ccpi/optimisation/functions/BlockFunction.py
@@ -20,6 +20,11 @@
 #
 #=========================================================================
 
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 from ccpi.optimisation.functions import Function
 from ccpi.framework import BlockDataContainer
 from numbers import Number

--- a/Wrappers/Python/ccpi/optimisation/functions/Function.py
+++ b/Wrappers/Python/ccpi/optimisation/functions/Function.py
@@ -20,6 +20,11 @@
 #
 #=========================================================================
 
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 import warnings
 from ccpi.optimisation.functions.ScaledFunction import ScaledFunction
 

--- a/Wrappers/Python/ccpi/optimisation/functions/FunctionOperatorComposition.py
+++ b/Wrappers/Python/ccpi/optimisation/functions/FunctionOperatorComposition.py
@@ -39,8 +39,11 @@ class FunctionOperatorComposition(Function):
         
         self.function = function     
         self.operator = operator
-        self.L = function.L * operator.norm()**2 
-        
+        try:
+            self.L = function.L * operator.norm()**2 
+        except Error as er:
+            self.L = None
+            warnings.warn("Lipschitz constant was not calculated")
         
     def __call__(self, x):
         
@@ -56,12 +59,13 @@ class FunctionOperatorComposition(Function):
             
         '''
         
+        tmp = self.operator.range_geometry().allocate()
+        self.operator.direct(x, out=tmp)
+        self.function.gradient(tmp, out=tmp)
         if out is None:
-            return self.operator.adjoint(self.function.gradient(self.operator.direct(x)))
+            #return self.operator.adjoint(self.function.gradient(self.operator.direct(x)))
+            return self.operator.adjoint(tmp)
         else: 
-            tmp = self.operator.range_geometry().allocate()
-            self.operator.direct(x, out=tmp)
-            self.function.gradient(tmp, out=tmp)
             self.operator.adjoint(tmp, out=out)
 
     

--- a/Wrappers/Python/ccpi/optimisation/functions/IndicatorBox.py
+++ b/Wrappers/Python/ccpi/optimisation/functions/IndicatorBox.py
@@ -16,6 +16,11 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 from ccpi.optimisation.functions import Function
 import numpy
 

--- a/Wrappers/Python/ccpi/optimisation/functions/KullbackLeibler.py
+++ b/Wrappers/Python/ccpi/optimisation/functions/KullbackLeibler.py
@@ -17,6 +17,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 import numpy
 from ccpi.optimisation.functions import Function
 from ccpi.optimisation.functions.ScaledFunction import ScaledFunction 

--- a/Wrappers/Python/ccpi/optimisation/functions/L1Norm.py
+++ b/Wrappers/Python/ccpi/optimisation/functions/L1Norm.py
@@ -17,6 +17,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 from ccpi.optimisation.functions import Function
 from ccpi.optimisation.functions.ScaledFunction import ScaledFunction        
 from ccpi.optimisation.operators import ShrinkageOperator 

--- a/Wrappers/Python/ccpi/optimisation/functions/L2NormSquared.py
+++ b/Wrappers/Python/ccpi/optimisation/functions/L2NormSquared.py
@@ -18,6 +18,11 @@
 # limitations under the License.
 
 
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 from ccpi.optimisation.functions import Function
 from ccpi.optimisation.functions.ScaledFunction import ScaledFunction
 

--- a/Wrappers/Python/ccpi/optimisation/functions/MixedL21Norm.py
+++ b/Wrappers/Python/ccpi/optimisation/functions/MixedL21Norm.py
@@ -45,11 +45,11 @@ class MixedL21Norm(Function):
         '''
         if not isinstance(x, BlockDataContainer):
             raise ValueError('__call__ expected BlockDataContainer, got {}'.format(type(x))) 
-                                         
-        tmp = [ el**2 for el in x.containers ]
-        res = sum(tmp).sqrt().sum()
+        tmp = x.get_item(0) * 0
+        for el in x.containers:
+            tmp += el.power(2.)
+        return tmp.sqrt().sum()
 
-        return res
                             
     def gradient(self, x, out=None):
         return ValueError('Not Differentiable')

--- a/Wrappers/Python/ccpi/optimisation/functions/MixedL21Norm.py
+++ b/Wrappers/Python/ccpi/optimisation/functions/MixedL21Norm.py
@@ -27,6 +27,7 @@ from ccpi.optimisation.functions import Function, ScaledFunction
 from ccpi.framework import BlockDataContainer
 
 import functools
+import numpy
 
 class MixedL21Norm(Function):
     
@@ -89,16 +90,29 @@ class MixedL21Norm(Function):
 
 
         if out is None:                                        
-            tmp = [ el*el for el in x.containers]
-            res = sum(tmp).sqrt().maximum(1.0) 
-            frac = [el/res for el in x.containers]
-            return  BlockDataContainer(*frac)   
+            # tmp = [ el*el for el in x.containers]
+            # res = sum(tmp).sqrt().maximum(1.0) 
+            # frac = [el/res for el in x.containers]
+            # return  BlockDataContainer(*frac)   
+            tmp = x.get_item(0) * 0
+            for el in x.containers:
+                tmp += el.power(2.)
+            tmp.sqrt(out=tmp)
+            tmp.maximum(1.0, out=tmp)
+            frac = [ el.divide(tmp) for el in x.containers ]
+            return BlockDataContainer(*frac)
+            
                 
         else:
                             
             res1 = functools.reduce(lambda a,b: a + b*b, x.containers, x.get_item(0) * 0 )
-            res = res1.sqrt().maximum(1.0)
-            x.divide(res, out=out)
+            if False:
+                res = res1.sqrt().maximum(1.0)
+                x.divide(res, out=out)
+            else:
+                res1.sqrt(out=res1)
+                res1.maximum(1.0, out=res1)
+                x.divide(res1, out=out)
                                           
 
     def __rmul__(self, scalar):
@@ -111,6 +125,12 @@ class MixedL21Norm(Function):
         return ScaledFunction(self, scalar) 
 
 
+def sqrt_maximum(x, a):
+    y = numpy.sqrt(x)
+    if y >= a:
+        return y
+    else:
+        return a
 #
 if __name__ == '__main__':
     

--- a/Wrappers/Python/ccpi/optimisation/functions/MixedL21Norm.py
+++ b/Wrappers/Python/ccpi/optimisation/functions/MixedL21Norm.py
@@ -18,6 +18,11 @@
 # limitations under the License.
 
 
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 from ccpi.optimisation.functions import Function, ScaledFunction
 from ccpi.framework import BlockDataContainer
 

--- a/Wrappers/Python/ccpi/optimisation/functions/ScaledFunction.py
+++ b/Wrappers/Python/ccpi/optimisation/functions/ScaledFunction.py
@@ -17,6 +17,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 from numbers import Number
 import numpy
 import warnings

--- a/Wrappers/Python/ccpi/optimisation/functions/ZeroFunction.py
+++ b/Wrappers/Python/ccpi/optimisation/functions/ZeroFunction.py
@@ -18,6 +18,11 @@
 # limitations under the License.
 
 
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 from ccpi.optimisation.functions import Function
 
 class ZeroFunction(Function):

--- a/Wrappers/Python/ccpi/optimisation/operators/BlockOperator.py
+++ b/Wrappers/Python/ccpi/optimisation/operators/BlockOperator.py
@@ -20,8 +20,14 @@
 import numpy
 import functools
 from ccpi.framework import ImageData, BlockDataContainer, DataContainer
-from ccpi.optimisation.operators import Operator
+from ccpi.optimisation.operators import Operator, LinearOperator
 from ccpi.framework import BlockGeometry
+try:
+    from sirf import SIRF
+    from sirf.SIRF import DataContainer as SIRFDataContainer
+    has_sirf = True
+except ImportError as ie:
+    has_sirf = False
        
 class BlockOperator(Operator):
     r'''A Block matrix containing Operators
@@ -115,7 +121,23 @@ class BlockOperator(Operator):
         return self.operators[index]
     
     def norm(self, **kwargs):
-        norm = [op.norm(**kwargs)**2 for op in self.operators]
+        '''Returns the norm of the BlockOperator
+
+        if the operator in the block do not have method norm defined, i.e. they are SIRF
+        AcquisitionModel's we use PowerMethod if applicable, otherwise we raise an Error
+        '''
+        norm = []
+        for op in self.operators:
+            if hasattr(op, 'norm'):
+                norm.append(op.norm(**kwargs) ** 2.)
+            else:
+                # use Power method
+                if op.is_linear():
+                    norm.append(
+                            LinearOperator.PowerMethod(op, 20)[0]
+                            )
+                else:
+                    raise TypeError('Operator {} does not have a norm method and is not linear'.format(op))
         return numpy.sqrt(sum(norm))    
     
     def direct(self, x, out=None):
@@ -188,7 +210,8 @@ class BlockOperator(Operator):
                         prod += self.get_item(row, col).adjoint(x_b.get_item(row))
                 res.append(prod)
             if self.shape[1]==1:
-                return ImageData(*res)
+                # the output is a single DataContainer, so we can take it out
+                return res[0]
             else:
                 return BlockDataContainer(*res, shape=shape)
         else:
@@ -196,7 +219,8 @@ class BlockOperator(Operator):
             for col in range(self.shape[1]):
                 for row in range(self.shape[0]):
                     if row == 0:
-                        if issubclass(out.__class__, DataContainer):
+                        if issubclass(out.__class__, DataContainer) or \
+                ( has_sirf and issubclass(out.__class__, SIRFDataContainer) ):
                             self.get_item(row, col).adjoint(
                                                 x_b.get_item(row),
                                                 out=out)
@@ -206,7 +230,8 @@ class BlockOperator(Operator):
                                                 x_b.get_item(row),
                                                 out=out.get_item(col))
                     else:
-                        if issubclass(out.__class__, DataContainer):
+                        if issubclass(out.__class__, DataContainer) or \
+                ( has_sirf and issubclass(out.__class__, SIRFDataContainer) ):
                             out += self.get_item(row,col).adjoint(
                                                         x_b.get_item(row))
                         else:

--- a/Wrappers/Python/ccpi/optimisation/operators/BlockOperator.py
+++ b/Wrappers/Python/ccpi/optimisation/operators/BlockOperator.py
@@ -17,6 +17,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 import numpy
 import functools
 from ccpi.framework import ImageData, BlockDataContainer, DataContainer

--- a/Wrappers/Python/ccpi/optimisation/operators/BlockScaledOperator.py
+++ b/Wrappers/Python/ccpi/optimisation/operators/BlockScaledOperator.py
@@ -18,6 +18,11 @@
 # limitations under the License.
 
 
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 from numbers import Number
 import numpy
 from ccpi.optimisation.operators import ScaledOperator

--- a/Wrappers/Python/ccpi/optimisation/operators/FiniteDifferenceOperator.py
+++ b/Wrappers/Python/ccpi/optimisation/operators/FiniteDifferenceOperator.py
@@ -70,6 +70,7 @@ class FiniteDiff(LinearOperator):
             #out = np.zeros_like(x_asarr)
             out = res.as_array()
         else:
+            res = out
             out = out.as_array()
             out[:]=0
                   
@@ -197,6 +198,7 @@ class FiniteDiff(LinearOperator):
             res = x * 0
             out = res.as_array()
         else:
+            res = out
             out = out.as_array()        
             out[:]=0
 

--- a/Wrappers/Python/ccpi/optimisation/operators/FiniteDifferenceOperator.py
+++ b/Wrappers/Python/ccpi/optimisation/operators/FiniteDifferenceOperator.py
@@ -66,7 +66,9 @@ class FiniteDiff(LinearOperator):
         x_sz = len(x.shape)
         
         if out is None:        
-            out = np.zeros_like(x_asarr)
+            res = x * 0
+            #out = np.zeros_like(x_asarr)
+            out = res.as_array()
         else:
             out = out.as_array()
             out[:]=0
@@ -180,7 +182,9 @@ class FiniteDiff(LinearOperator):
             raise NotImplementedError                
          
 #        res = out #/self.voxel_size 
-        return type(x)(out)
+        #return type(x)(out)
+        res.fill(out)
+        return res
 
                     
     def adjoint(self, x, out=None):
@@ -189,7 +193,9 @@ class FiniteDiff(LinearOperator):
         x_sz = len(x.shape)
         
         if out is None:        
-            out = np.zeros_like(x_asarr)
+            #out = np.zeros_like(x_asarr)
+            res = x * 0
+            out = res.as_array()
         else:
             out = out.as_array()        
             out[:]=0
@@ -319,7 +325,9 @@ class FiniteDiff(LinearOperator):
             raise NotImplementedError
             
         out *= -1 #/self.voxel_size
-        return type(x)(out)
+        #return type(x)(out)
+        res.fill(out)
+        return res
             
     def range_geometry(self):
         

--- a/Wrappers/Python/ccpi/optimisation/operators/FiniteDifferenceOperator.py
+++ b/Wrappers/Python/ccpi/optimisation/operators/FiniteDifferenceOperator.py
@@ -15,6 +15,11 @@
 #   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 from ccpi.optimisation.operators import LinearOperator
 import numpy as np
 

--- a/Wrappers/Python/ccpi/optimisation/operators/GradientOperator.py
+++ b/Wrappers/Python/ccpi/optimisation/operators/GradientOperator.py
@@ -15,6 +15,11 @@
 #   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 from ccpi.optimisation.operators import Operator, LinearOperator, ScaledOperator
 from ccpi.framework import ImageData, ImageGeometry, BlockGeometry, BlockDataContainer
 import numpy 

--- a/Wrappers/Python/ccpi/optimisation/operators/IdentityOperator.py
+++ b/Wrappers/Python/ccpi/optimisation/operators/IdentityOperator.py
@@ -16,6 +16,11 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 from ccpi.optimisation.operators import LinearOperator
 import scipy.sparse as sp
 import numpy as np

--- a/Wrappers/Python/ccpi/optimisation/operators/LinearOperator.py
+++ b/Wrappers/Python/ccpi/optimisation/operators/LinearOperator.py
@@ -15,7 +15,12 @@
 #   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
+
+from __future__ import absolute_import
 from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 from ccpi.optimisation.operators import Operator
 import numpy
 
@@ -39,7 +44,7 @@ class LinearOperator(Operator):
         
         # Initialise random
         if x_init is None:
-            x0 = operator.domain_geometry().allocate('random_int')
+            x0 = operator.domain_geometry().allocate('random')
         else:
             x0 = x_init.copy()
             
@@ -51,7 +56,11 @@ class LinearOperator(Operator):
             operator.direct(x0,out=y_tmp)
             operator.adjoint(y_tmp,out=x1)
             x1norm = x1.norm()
-            s[it] = x1.dot(x0) / x0.squared_norm()
+            if hasattr(x0, 'squared_norm'):
+                s[it] = x1.dot(x0) / x0.squared_norm()
+            else:
+                x0norm = x0.norm()
+                s[it] = x1.dot(x0) / (x0norm * x0norm) 
             x1.multiply((1.0/x1norm), out=x0)
         return numpy.sqrt(s[-1]), numpy.sqrt(s), x0
 

--- a/Wrappers/Python/ccpi/optimisation/operators/LinearOperator.py
+++ b/Wrappers/Python/ccpi/optimisation/operators/LinearOperator.py
@@ -71,4 +71,41 @@ class LinearOperator(Operator):
         s1, sall, svec = LinearOperator.PowerMethod(self, iterations, x_init=x0)
         return s1
 
-
+    @staticmethod
+    def dot_test(operator, domain_init=None, range_init=None, verbose=False):
+        '''Does a dot linearity test on the operator
+        
+        Evaluates if the following equivalence holds
+        
+        :math: ..
+        
+          Ax\times y = y \times A^Tx
+        
+        :param operator: operator to test
+        :param range_init: optional initialisation container in the operator range 
+        :param domain_init: optional initialisation container in the operator domain 
+        :returns: boolean, True if the test is passed.
+        '''
+        if range_init is None:
+            y = operator.range_geometry().allocate('random_int')
+        else:
+            y = range_init
+        if domain_init is None:
+            x = operator.domain_geometry().allocate('random_int')
+        else:
+            x = domain_init
+            
+        fx = operator.direct(x)
+        by = operator.adjoint(y)
+        a = fx.dot(y)
+        b = by.dot(x)
+        if verbose:
+            print ('Left hand side  {}, \nRight hand side {}'.format(a, b))
+        try:
+            numpy.testing.assert_almost_equal(abs((a-b)/a), 0, decimal=4)
+            return True
+        except AssertionError as ae:
+            print (ae)
+            return False
+        
+        

--- a/Wrappers/Python/ccpi/optimisation/operators/LinearOperator.py
+++ b/Wrappers/Python/ccpi/optimisation/operators/LinearOperator.py
@@ -15,7 +15,7 @@
 #   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
-
+from __future__ import division
 from ccpi.optimisation.operators import Operator
 import numpy
 
@@ -39,7 +39,7 @@ class LinearOperator(Operator):
         
         # Initialise random
         if x_init is None:
-            x0 = operator.domain_geometry().allocate(type(operator.domain_geometry()).RANDOM_INT)
+            x0 = operator.domain_geometry().allocate('random_int')
         else:
             x0 = x_init.copy()
             

--- a/Wrappers/Python/ccpi/optimisation/operators/LinearOperatorMatrix.py
+++ b/Wrappers/Python/ccpi/optimisation/operators/LinearOperatorMatrix.py
@@ -15,6 +15,12 @@
 #   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 import numpy
 from scipy.sparse.linalg import svds
 from ccpi.framework import VectorGeometry

--- a/Wrappers/Python/ccpi/optimisation/operators/Operator.py
+++ b/Wrappers/Python/ccpi/optimisation/operators/Operator.py
@@ -15,6 +15,12 @@
 #   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+
 from ccpi.optimisation.operators.ScaledOperator import ScaledOperator
 
 class Operator(object):

--- a/Wrappers/Python/ccpi/optimisation/operators/ShrinkageOperator.py
+++ b/Wrappers/Python/ccpi/optimisation/operators/ShrinkageOperator.py
@@ -15,6 +15,11 @@
 #   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 
 from ccpi.framework import DataContainer
 

--- a/Wrappers/Python/ccpi/optimisation/operators/SparseFiniteDiff.py
+++ b/Wrappers/Python/ccpi/optimisation/operators/SparseFiniteDiff.py
@@ -15,6 +15,11 @@
 #   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 
 import scipy.sparse as sp
 import numpy as np

--- a/Wrappers/Python/ccpi/optimisation/operators/SymmetrizedGradientOperator.py
+++ b/Wrappers/Python/ccpi/optimisation/operators/SymmetrizedGradientOperator.py
@@ -15,9 +15,16 @@
 #   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
 
-from ccpi.optimisation.operators import Gradient, Operator, LinearOperator, ScaledOperator
-from ccpi.framework import ImageData, ImageGeometry, BlockGeometry, BlockDataContainer
+
+from ccpi.optimisation.operators import Gradient, Operator, LinearOperator,\
+        ScaledOperator
+from ccpi.framework import ImageData, ImageGeometry, BlockGeometry, \
+        BlockDataContainer
 import numpy 
 from ccpi.optimisation.operators import FiniteDiff
 

--- a/Wrappers/Python/ccpi/optimisation/operators/ZeroOperator.py
+++ b/Wrappers/Python/ccpi/optimisation/operators/ZeroOperator.py
@@ -15,6 +15,11 @@
 #   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 
 import numpy as np
 from ccpi.framework import ImageData

--- a/Wrappers/Python/test/test_NexusReader.py
+++ b/Wrappers/Python/test/test_NexusReader.py
@@ -17,7 +17,11 @@
 #   limitations under the License.
 
 import unittest
-import wget
+has_wget = True
+try:
+    import wget
+except ImportError as ie:
+    has_wget = False
 import os
 from ccpi.io.reader import NexusReader
 import numpy
@@ -26,80 +30,85 @@ import numpy
 class TestNexusReader(unittest.TestCase):
 
     def setUp(self):
-        wget.download('https://github.com/DiamondLightSource/Savu/raw/master/test_data/data/24737_fd.nxs')
-        self.filename = '24737_fd.nxs'
+        if has_wget:
+            wget.download('https://github.com/DiamondLightSource/Savu/raw/master/test_data/data/24737_fd.nxs')
+            self.filename = '24737_fd.nxs'
 
     def tearDown(self):
-        os.remove(self.filename)
+        if has_wget:
+            os.remove(self.filename)
 
     def testAll(self):
-    # def testGetDimensions(self):
-        nr = NexusReader(self.filename)
-        self.assertEqual(nr.get_sinogram_dimensions(), (135, 91, 160), "Sinogram dimensions are not correct")
-        
-    # def testGetProjectionDimensions(self):
-        nr = NexusReader(self.filename)
-        self.assertEqual(nr.get_projection_dimensions(), (91,135,160), "Projection dimensions are not correct")        
-        
-    # def testLoadProjectionWithoutDimensions(self):
-        nr = NexusReader(self.filename)
-        projections = nr.load_projection()        
-        self.assertEqual(projections.shape, (91,135,160), "Loaded projection data dimensions are not correct")        
+        if has_wget:
+        # def testGetDimensions(self):
+            nr = NexusReader(self.filename)
+            self.assertEqual(nr.get_sinogram_dimensions(), (135, 91, 160), "Sinogram dimensions are not correct")
 
-    # def testLoadProjectionWithDimensions(self):
-        nr = NexusReader(self.filename)
-        projections = nr.load_projection((slice(0,1), slice(0,135), slice(0,160)))        
-        self.assertEqual(projections.shape, (1,135,160), "Loaded projection data dimensions are not correct")        
-            
-    # def testLoadProjectionCompareSingle(self):
-        nr = NexusReader(self.filename)
-        projections_full = nr.load_projection()
-        projections_part = nr.load_projection((slice(0,1), slice(0,135), slice(0,160))) 
-        numpy.testing.assert_array_equal(projections_part, projections_full[0:1,:,:])
-        
-    # def testLoadProjectionCompareMulti(self):
-        nr = NexusReader(self.filename)
-        projections_full = nr.load_projection()
-        projections_part = nr.load_projection((slice(0,3), slice(0,135), slice(0,160))) 
-        numpy.testing.assert_array_equal(projections_part, projections_full[0:3,:,:])
-        
-    # def testLoadProjectionCompareRandom(self):
-        nr = NexusReader(self.filename)
-        projections_full = nr.load_projection()
-        projections_part = nr.load_projection((slice(1,8), slice(5,10), slice(8,20))) 
-        numpy.testing.assert_array_equal(projections_part, projections_full[1:8,5:10,8:20])                
-        
-    # def testLoadProjectionCompareFull(self):
-        nr = NexusReader(self.filename)
-        projections_full = nr.load_projection()
-        projections_part = nr.load_projection((slice(None,None), slice(None,None), slice(None,None))) 
-        numpy.testing.assert_array_equal(projections_part, projections_full[:,:,:])
-        
-    # def testLoadFlatCompareFull(self):
-        nr = NexusReader(self.filename)
-        flats_full = nr.load_flat()
-        flats_part = nr.load_flat((slice(None,None), slice(None,None), slice(None,None))) 
-        numpy.testing.assert_array_equal(flats_part, flats_full[:,:,:])
-        
-    # def testLoadDarkCompareFull(self):
-        nr = NexusReader(self.filename)
-        darks_full = nr.load_dark()
-        darks_part = nr.load_dark((slice(None,None), slice(None,None), slice(None,None))) 
-        numpy.testing.assert_array_equal(darks_part, darks_full[:,:,:])
-        
-    # def testProjectionAngles(self):
-        nr = NexusReader(self.filename)
-        angles = nr.get_projection_angles()
-        self.assertEqual(angles.shape, (91,), "Loaded projection number of angles are not correct")        
-        
-    # def test_get_acquisition_data_subset(self):
-        nr = NexusReader(self.filename)
-        key = nr.get_image_keys()
-        sl = nr.get_acquisition_data_subset(0,10)
-        data = nr.get_acquisition_data().subset(['vertical','horizontal'])
-        
-        self.assertTrue(sl.shape , (10,data.shape[1]))
+        # def testGetProjectionDimensions(self):
+            nr = NexusReader(self.filename)
+            self.assertEqual(nr.get_projection_dimensions(), (91,135,160), "Projection dimensions are not correct")        
 
+        # def testLoadProjectionWithoutDimensions(self):
+            nr = NexusReader(self.filename)
+            projections = nr.load_projection()        
+            self.assertEqual(projections.shape, (91,135,160), "Loaded projection data dimensions are not correct")        
+
+        # def testLoadProjectionWithDimensions(self):
+            nr = NexusReader(self.filename)
+            projections = nr.load_projection((slice(0,1), slice(0,135), slice(0,160)))        
+            self.assertEqual(projections.shape, (1,135,160), "Loaded projection data dimensions are not correct")        
+
+        # def testLoadProjectionCompareSingle(self):
+            nr = NexusReader(self.filename)
+            projections_full = nr.load_projection()
+            projections_part = nr.load_projection((slice(0,1), slice(0,135), slice(0,160))) 
+            numpy.testing.assert_array_equal(projections_part, projections_full[0:1,:,:])
+
+        # def testLoadProjectionCompareMulti(self):
+            nr = NexusReader(self.filename)
+            projections_full = nr.load_projection()
+            projections_part = nr.load_projection((slice(0,3), slice(0,135), slice(0,160))) 
+            numpy.testing.assert_array_equal(projections_part, projections_full[0:3,:,:])
+
+        # def testLoadProjectionCompareRandom(self):
+            nr = NexusReader(self.filename)
+            projections_full = nr.load_projection()
+            projections_part = nr.load_projection((slice(1,8), slice(5,10), slice(8,20))) 
+            numpy.testing.assert_array_equal(projections_part, projections_full[1:8,5:10,8:20])                
+
+        # def testLoadProjectionCompareFull(self):
+            nr = NexusReader(self.filename)
+            projections_full = nr.load_projection()
+            projections_part = nr.load_projection((slice(None,None), slice(None,None), slice(None,None))) 
+            numpy.testing.assert_array_equal(projections_part, projections_full[:,:,:])
+
+        # def testLoadFlatCompareFull(self):
+            nr = NexusReader(self.filename)
+            flats_full = nr.load_flat()
+            flats_part = nr.load_flat((slice(None,None), slice(None,None), slice(None,None))) 
+            numpy.testing.assert_array_equal(flats_part, flats_full[:,:,:])
+
+        # def testLoadDarkCompareFull(self):
+            nr = NexusReader(self.filename)
+            darks_full = nr.load_dark()
+            darks_part = nr.load_dark((slice(None,None), slice(None,None), slice(None,None))) 
+            numpy.testing.assert_array_equal(darks_part, darks_full[:,:,:])
+
+        # def testProjectionAngles(self):
+            nr = NexusReader(self.filename)
+            angles = nr.get_projection_angles()
+            self.assertEqual(angles.shape, (91,), "Loaded projection number of angles are not correct")        
+
+        # def test_get_acquisition_data_subset(self):
+            nr = NexusReader(self.filename)
+            key = nr.get_image_keys()
+            sl = nr.get_acquisition_data_subset(0,10)
+            data = nr.get_acquisition_data().subset(['vertical','horizontal'])
+
+            self.assertTrue(sl.shape , (10,data.shape[1]))
+        else:
+            # skips all tests if module wget is not present
+            self.assertFalse(has_wget)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR includes **changes for python2.7** support (hence all the files have changed).

Adds type check for SIRF objects, in [`BlockDataContainer`](https://github.com/vais-ral/CCPi-Framework/blob/506f9ebad8737ebb32d4ff99fb802f84bc837bb4/Wrappers/Python/ccpi/framework/BlockDataContainer.py#L112). 

This is not very nice and possibly it isn't necessary as one could just rely on the fact that SIRF and CIL `DataContainer` present the same interface. 