### PR TITLE
fix function style

### DIFF
--- a/Wrappers/Python/ccpi/optimisation/functions/BlockFunction.py
+++ b/Wrappers/Python/ccpi/optimisation/functions/BlockFunction.py
@@ -172,7 +172,7 @@ if __name__ == '__main__':
     b = ig.allocate('random_int')
     
     f1 =  10 * MixedL21Norm()
-    f2 =  0.5 * L2NormSquared(b=b)    
+    f2 =  0.5 * L2NormSquared(b)    
     
     f = BlockFunction(f1, f2)
     tau = 0.3

--- a/Wrappers/Python/ccpi/optimisation/functions/FunctionOperatorComposition.py
+++ b/Wrappers/Python/ccpi/optimisation/functions/FunctionOperatorComposition.py
@@ -103,7 +103,7 @@ if __name__ == '__main__':
 #    G = Gradient(ig)
     alpha = 0.5
     
-    f1 =  alpha * L2NormSquared(b=b)    
+    f1 =  alpha * L2NormSquared(b)    
 
     f_comp = FunctionOperatorComposition(f1, Aop)
     

--- a/Wrappers/Python/ccpi/optimisation/functions/KullbackLeibler.py
+++ b/Wrappers/Python/ccpi/optimisation/functions/KullbackLeibler.py
@@ -40,12 +40,15 @@ class KullbackLeibler(Function):
             
     '''
     
-    def __init__(self, data, **kwargs):
+    def __init__(self, data = None, **kwargs):
         
         super(KullbackLeibler, self).__init__()
         
         self.b = data    
-        self.bnoise = kwargs.get('bnoise',data * 0.0)
+        self.bnoise = kwargs.get('background_noise',data * 0.0)
+        
+        if data is None:
+            raise ValueError('Please define data')
         
                                                     
     def __call__(self, x):

--- a/Wrappers/Python/ccpi/optimisation/functions/KullbackLeibler.py
+++ b/Wrappers/Python/ccpi/optimisation/functions/KullbackLeibler.py
@@ -81,8 +81,7 @@ class KullbackLeibler(Function):
         
         if out is None:            
             return 1 - self.data[ind]/tmp_sum[ind]
-        else:
-            
+        else:            
             # TODO not working with ind
             x.add(self.background_term, out=out)
             self.data.divide(out, out=out)

--- a/Wrappers/Python/ccpi/optimisation/functions/KullbackLeibler.py
+++ b/Wrappers/Python/ccpi/optimisation/functions/KullbackLeibler.py
@@ -45,7 +45,7 @@ class KullbackLeibler(Function):
         super(KullbackLeibler, self).__init__()
         
         self.b = data    
-        self.bnoise = 0
+        self.bnoise = kwargs.get('bnoise',data * 0.0)
         
                                                     
     def __call__(self, x):

--- a/Wrappers/Python/ccpi/optimisation/functions/L1Norm.py
+++ b/Wrappers/Python/ccpi/optimisation/functions/L1Norm.py
@@ -40,7 +40,7 @@ class L1Norm(Function):
     def __init__(self, data = None, **kwargs):
         
         super(L1Norm, self).__init__()
-        self.b = data
+        self.data = data
         self.shinkage_operator = ShrinkageOperator()
         
     def __call__(self, x):
@@ -48,8 +48,8 @@ class L1Norm(Function):
         '''Evaluates L1Norm at x'''
         
         y = x
-        if self.b is not None: 
-            y = x - self.b
+        if self.data is not None: 
+            y = x - self.data
         return y.abs().sum()  
     
     def gradient(self,x):
@@ -61,8 +61,8 @@ class L1Norm(Function):
         '''Convex conjugate of L1Norm at x'''
 
         y = 0        
-        if self.b is not None:
-            y =  0 + self.b.dot(x)
+        if self.data is not None:
+            y =  0 + self.data.dot(x)
         return y  
     
     def proximal(self, x, tau, out=None):
@@ -74,13 +74,13 @@ class L1Norm(Function):
         ''' 
         
         if out is None:
-            if self.b is not None:
-                return self.b + self.shinkage_operator(x - self.b, tau)
+            if self.data is not None:
+                return self.data + self.shinkage_operator(x - self.data, tau)
             else:
                 return self.shinkage_operator(x, tau)             
         else:
             if self.b is not None:
-                out.fill(self.b + self.shinkage_operator(x - self.b, tau))
+                out.fill(self.data + self.shinkage_operator(x - self.data, tau))
             else:
                 out.fill(self.shinkage_operator(x, tau))
                                     
@@ -93,13 +93,13 @@ class L1Norm(Function):
         '''          
         
         if out is None:
-            if self.b is not None:
-                return (x - tau*self.b).divide((x - tau*self.b).abs().maximum(1.0))
+            if self.data is not None:
+                return (x - tau*self.data).divide((x - tau*self.data).abs().maximum(1.0))
             else:
                 return x.divide(x.abs().maximum(1.0))
         else:
             if self.b is not None:
-                out.fill((x - tau*self.b).divide((x - tau*self.b).abs().maximum(1.0)))
+                out.fill((x - tau*self.data).divide((x - tau*self.data).abs().maximum(1.0)))
             else:
                 out.fill(x.divide(x.abs().maximum(1.0)) )                
             
@@ -126,8 +126,8 @@ if __name__ == '__main__':
     f = L1Norm()
     f_scaled = scalar * L1Norm()
 
-    f_b = L1Norm(b=b)
-    f_scaled_b = scalar * L1Norm(b=b)
+    f_b = L1Norm(b)
+    f_scaled_b = scalar * L1Norm(b)
     
     # call  
         

--- a/Wrappers/Python/ccpi/optimisation/functions/L1Norm.py
+++ b/Wrappers/Python/ccpi/optimisation/functions/L1Norm.py
@@ -37,10 +37,10 @@ class L1Norm(Function):
                                 
     '''   
            
-    def __init__(self, **kwargs):
+    def __init__(self, data = None, **kwargs):
         
         super(L1Norm, self).__init__()
-        self.b = kwargs.get('b',None)
+        self.b = data
         self.shinkage_operator = ShrinkageOperator()
         
     def __call__(self, x):

--- a/Wrappers/Python/ccpi/optimisation/functions/L1Norm.py
+++ b/Wrappers/Python/ccpi/optimisation/functions/L1Norm.py
@@ -79,7 +79,7 @@ class L1Norm(Function):
             else:
                 return self.shinkage_operator(x, tau)             
         else:
-            if self.b is not None:
+            if self.data is not None:
                 out.fill(self.data + self.shinkage_operator(x - self.data, tau))
             else:
                 out.fill(self.shinkage_operator(x, tau))
@@ -98,7 +98,7 @@ class L1Norm(Function):
             else:
                 return x.divide(x.abs().maximum(1.0))
         else:
-            if self.b is not None:
+            if self.data is not None:
                 out.fill((x - tau*self.data).divide((x - tau*self.data).abs().maximum(1.0)))
             else:
                 out.fill(x.divide(x.abs().maximum(1.0)) )                

--- a/Wrappers/Python/ccpi/optimisation/functions/L2NormSquared.py
+++ b/Wrappers/Python/ccpi/optimisation/functions/L2NormSquared.py
@@ -106,7 +106,7 @@ class L2NormSquared(Function):
 
         else:
             if self.data is not None:
-                x.subtract(self.dat, out=out)
+                x.subtract(self.data, out=out)
                 out /= (1+2*tau)
                 out += self.data
             else:

--- a/Wrappers/Python/ccpi/optimisation/functions/L2NormSquared.py
+++ b/Wrappers/Python/ccpi/optimisation/functions/L2NormSquared.py
@@ -36,11 +36,10 @@ class L2NormSquared(Function):
                                 
     '''    
     
-    def __init__(self, **kwargs):
+    def __init__(self, data = None,  **kwargs):
                                 
         super(L2NormSquared, self).__init__()
-        self.b = kwargs.get('b',None) 
-        
+        self.b = data
         # Lipschitz constant
         self.L = 2
 

--- a/Wrappers/Python/ccpi/optimisation/functions/L2NormSquared.py
+++ b/Wrappers/Python/ccpi/optimisation/functions/L2NormSquared.py
@@ -82,7 +82,7 @@ class L2NormSquared(Function):
         tmp = 0
         
         if self.data is not None:
-            tmp = x.dot(self.data) #(x * self.b).sum()
+            tmp = x.dot(self.data) 
             
         return (1./4.) * x.squared_norm() + tmp
 
@@ -241,22 +241,22 @@ if __name__ == '__main__':
     
     
     
-    print( " ####### check without out ######### " )
-          
-          
-    u_out_no_out = ig.allocate('random_int')         
-    res_no_out = f_scaled_data.proximal_conjugate(u_out_no_out, 0.5)          
-    print(res_no_out.as_array())
-    
-    print( " ####### check with out ######### " ) 
-          
-    res_out = ig.allocate()        
-    f_scaled_data.proximal_conjugate(u_out_no_out, 0.5, out = res_out)
-    
-    print(res_out.as_array())   
-
-    numpy.testing.assert_array_almost_equal(res_no_out.as_array(), \
-                                            res_out.as_array(), decimal=4)  
+#    print( " ####### check without out ######### " )
+#          
+#          
+#    u_out_no_out = ig.allocate('random_int')         
+#    res_no_out = f_scaled_data.proximal_conjugate(u_out_no_out, 0.5)          
+#    print(res_no_out.as_array())
+#    
+#    print( " ####### check with out ######### " ) 
+#          
+#    res_out = ig.allocate()        
+#    f_scaled_data.proximal_conjugate(u_out_no_out, 0.5, out = res_out)
+#    
+#    print(res_out.as_array())   
+#
+#    numpy.testing.assert_array_almost_equal(res_no_out.as_array(), \
+#                                            res_out.as_array(), decimal=4)  
     
     
     

--- a/Wrappers/Python/ccpi/optimisation/functions/L2NormSquared.py
+++ b/Wrappers/Python/ccpi/optimisation/functions/L2NormSquared.py
@@ -39,7 +39,7 @@ class L2NormSquared(Function):
     def __init__(self, data = None,  **kwargs):
                                 
         super(L2NormSquared, self).__init__()
-        self.b = data
+        self.data = data
         # Lipschitz constant
         self.L = 2
 
@@ -48,8 +48,8 @@ class L2NormSquared(Function):
         '''Evaluates L2NormSquared at x'''
             
         y = x
-        if self.b is not None: 
-            y = x - self.b
+        if self.data is not None: 
+            y = x - self.data
         try:
             return y.squared_norm()
         except AttributeError as ae:
@@ -63,15 +63,15 @@ class L2NormSquared(Function):
         if out is not None:
             
             out.fill(x)
-            if self.b is not None:
-                out -= self.b
+            if self.data is not None:
+                out -= self.data
             out *= 2
             
         else:
             
             y = x
-            if self.b is not None:
-                y = x - self.b
+            if self.data is not None:
+                y = x - self.data
             return 2*y
         
                                                        
@@ -81,8 +81,8 @@ class L2NormSquared(Function):
         
         tmp = 0
         
-        if self.b is not None:
-            tmp = x.dot(self.b) #(x * self.b).sum()
+        if self.data is not None:
+            tmp = x.dot(self.data) #(x * self.b).sum()
             
         return (1./4.) * x.squared_norm() + tmp
 
@@ -96,19 +96,19 @@ class L2NormSquared(Function):
         
         if out is None:
             
-            if self.b is None:
+            if self.data is None:
                 return x/(1+2*tau)
             else:
-                tmp = x.subtract(self.b)
+                tmp = x.subtract(self.data)
                 tmp /= (1+2*tau)
-                tmp += self.b
+                tmp += self.data
                 return tmp
 
         else:
-            if self.b is not None:
-                x.subtract(self.b, out=out)
+            if self.data is not None:
+                x.subtract(self.dat, out=out)
                 out /= (1+2*tau)
-                out += self.b
+                out += self.data
             else:
                 x.divide((1+2*tau), out=out)
 
@@ -120,13 +120,13 @@ class L2NormSquared(Function):
            .. math::  prox_{\tau * f^{*}}(x)'''
         
         if out is None:
-            if self.b is not None:
-                return (x - tau*self.b)/(1 + tau/2) 
+            if self.data is not None:
+                return (x - tau*self.data)/(1 + tau/2) 
             else:
                 return x/(1 + tau/2)
         else:
-            if self.b is not None:
-                x.subtract(tau*self.b, out=out)
+            if self.data is not None:
+                x.subtract(tau*self.data, out=out)
                 out.divide(1+tau/2, out=out)
             else:
                 x.divide(1 + tau/2, out=out)
@@ -160,7 +160,7 @@ if __name__ == '__main__':
     numpy.testing.assert_equal(f(u), u.squared_norm())
 
     # check grad/call with data
-    f1 = L2NormSquared(b=b)
+    f1 = L2NormSquared(b)
     b1 = f1.gradient(u)
     b2 = 2 * (u-b)
         
@@ -206,7 +206,7 @@ if __name__ == '__main__':
     # scalar 
     scalar = 100
     f_scaled_no_data = scalar * L2NormSquared()
-    f_scaled_data = scalar * L2NormSquared(b=b)
+    f_scaled_data = scalar * L2NormSquared(b)
     
     # call
     numpy.testing.assert_equal(f_scaled_no_data(u), scalar*f(u))
@@ -268,8 +268,8 @@ if __name__ == '__main__':
     b = ig1.allocate('random_int')
     
     scalar = 0.5
-    f_scaled = scalar * L2NormSquared(b=b)
-    f_noscaled = L2NormSquared(b=b)
+    f_scaled = scalar * L2NormSquared(b)
+    f_noscaled = L2NormSquared(b)
     
     
     res1 = f_scaled.proximal(u, tau)

--- a/Wrappers/Python/ccpi/optimisation/functions/ScaledFunction.py
+++ b/Wrappers/Python/ccpi/optimisation/functions/ScaledFunction.py
@@ -114,7 +114,7 @@ if __name__ == '__main__':
     BG = BlockGeometry(ig, ig)
     U = BG.allocate('random_int')
         
-    f2 = 0.5 * L2NormSquared(b=b)
+    f2 = 0.5 * L2NormSquared(b)
     f1 = 30 * MixedL21Norm()
     tau = 0.355
     

--- a/Wrappers/Python/ccpi/optimisation/operators/SymmetrizedGradientOperator.py
+++ b/Wrappers/Python/ccpi/optimisation/operators/SymmetrizedGradientOperator.py
@@ -21,15 +21,12 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 
-from ccpi.optimisation.operators import Gradient, Operator, LinearOperator,\
-        ScaledOperator
-from ccpi.framework import ImageData, ImageGeometry, BlockGeometry, \
-        BlockDataContainer
-import numpy 
+from ccpi.optimisation.operators import LinearOperator
+from ccpi.framework import BlockGeometry, BlockDataContainer
 from ccpi.optimisation.operators import FiniteDiff
 
 
-class SymmetrizedGradient(Gradient):
+class SymmetrizedGradient(LinearOperator):
     
     r'''Symmetrized Gradient Operator:  E: V -> W
         
@@ -49,21 +46,23 @@ class SymmetrizedGradient(Gradient):
               |                                                      
     '''
     
+    CORRELATION_SPACE = "Space"
+    CORRELATION_SPACECHANNEL = "SpaceChannels"
     
     def __init__(self, gm_domain, bnd_cond = 'Neumann', **kwargs):
         
-        super(SymmetrizedGradient, self).__init__(gm_domain, bnd_cond, **kwargs) 
+        super(SymmetrizedGradient, self).__init__() 
                 
-        self.gm_domain = self.gm_range 
+        self.gm_domain = gm_domain
         self.bnd_cond = bnd_cond
-        
-        self.channels = self.gm_range.get_item(0).channels
-        
+        self.correlation = kwargs.get('correlation',SymmetrizedGradient.CORRELATION_SPACE)
+                
         tmp_gm = len(self.gm_domain.geometries)*self.gm_domain.geometries
         
         self.gm_range = BlockGeometry(*tmp_gm)
         
-        self.FD = FiniteDiff(self.gm_domain, direction = 0, bnd_cond = self.bnd_cond)
+        # Define FD operator. We need one geometry from the BlockGeometry of the domain
+        self.FD = FiniteDiff(self.gm_domain.get_item(0), direction = 0, bnd_cond = self.bnd_cond)
         
         if self.gm_domain.shape[0]==2:
             self.order_ind = [0,2,1,3]
@@ -130,8 +129,6 @@ class SymmetrizedGradient(Gradient):
                     i+=1
                     tmp1+=tmp[j]
                 out[k].fill(tmp1)
-#            tmp = self.adjoint(x)
-#            out.fill(tmp)
                     
                      
     def domain_geometry(self):
@@ -144,110 +141,59 @@ if __name__ == '__main__':
     
     ###########################################################################  
     ## Symmetrized Gradient Tests
-    from ccpi.framework import DataContainer
-    from ccpi.optimisation.operators import Gradient, BlockOperator, FiniteDiff
+    from ccpi.framework import ImageGeometry
+    from ccpi.optimisation.operators import Gradient
     import numpy as np
     
     N, M = 2, 3
     K = 2
     C = 2
     
-    ig1 = ImageGeometry(N, M)
-    ig2 = ImageGeometry(N, M, channels=C)
+    ###########################################################################
+    # 2D geometry no channels
+    ig = ImageGeometry(N, M)
+    Grad = Gradient(ig)
     
-    E1 = SymmetrizedGradient(ig1, correlation = 'Space', bnd_cond='Neumann')
+    E1 = SymmetrizedGradient(Grad.range_geometry())
+    np.testing.assert_almost_equal(E1.norm(), np.sqrt(8), 1e-5)
     
-    try:
-        E1 = SymmetrizedGradient(ig1, correlation = 'SpaceChannels', bnd_cond='Neumann')
-    except:
-        print("No Channels to correlate")
-        
-    E2 = SymmetrizedGradient(ig2, correlation = 'SpaceChannels', bnd_cond='Neumann')  
-
     print(E1.domain_geometry().shape, E1.range_geometry().shape)
-    print(E2.domain_geometry().shape, E2.range_geometry().shape)   
-    
-    #check Linear operator property
-    
     u1 = E1.domain_geometry().allocate('random_int')
+    w1 = E1.range_geometry().allocate('random_int', symmetry = True)
+       
+    
+    lhs = E1.direct(u1).dot(w1)
+    rhs = u1.dot(E1.adjoint(w1))
+    np.testing.assert_almost_equal(lhs, rhs)
+    
+    ###########################################################################
+    # 2D geometry with channels
+    ig2 = ImageGeometry(N, M, channels = C)
+    Grad2 = Gradient(ig2, correlation = 'Space')
+    
+    E2 = SymmetrizedGradient(Grad2.range_geometry())
+    np.testing.assert_almost_equal(E2.norm(), np.sqrt(12), 1e-6)
+    
+    print(E2.domain_geometry().shape, E2.range_geometry().shape)
     u2 = E2.domain_geometry().allocate('random_int')
+    w2 = E2.range_geometry().allocate('random_int', symmetry = True)
+#    
+    lhs2 = E2.direct(u2).dot(w2)
+    rhs2 = u2.dot(E2.adjoint(w2))
+    np.testing.assert_almost_equal(lhs2, rhs2)
     
-    # Need to allocate random_int at the Range of SymGradient
+    ###########################################################################
+    # 3D geometry no channels
+    ig3 = ImageGeometry(N, M, K)
+    Grad3 = Gradient(ig3, correlation = 'Space')
     
-    #a1 = ig1.allocate('random_int')
-    #a2 = ig1.allocate('random_int')
-    #a3 = ig1.allocate('random_int')
+    E3 = SymmetrizedGradient(Grad3.range_geometry())
+    np.testing.assert_almost_equal(E3.norm(), np.sqrt(12), 1e-6)
     
-    #a4 = ig1.allocate('random_int')
-    #a5 = ig1.allocate('random_int')    
-    #a6 = ig1.allocate('random_int')
-    
-    # TODO allocate has to create this symmetry by default!!!!!
-    #w1 = BlockDataContainer(*[a1, a2, \
-    #                           a2, a3]) 
-    w1 = E1.range_geometry().allocate('random_int',symmetry=True)
-    
-    LHS = (E1.direct(u1) * w1).sum()
-    RHS = (u1 * E1.adjoint(w1)).sum()
-    
-    numpy.testing.assert_equal(LHS, RHS)     
-    
-    u2 = E2.gm_domain.allocate('random_int')
-    
-    #aa1 = ig2.allocate('random_int')
-    #aa2 = ig2.allocate('random_int')
-    #aa3 = ig2.allocate('random_int')
-    #aa4 = ig2.allocate('random_int')
-    #aa5 = ig2.allocate('random_int')
-    #aa6 = ig2.allocate('random_int')  
-    
-    #w2 = BlockDataContainer(*[aa1, aa2, aa3, \
-    #                          aa2, aa4, aa5, \
-    #                          aa3, aa5, aa6])     
-    w2 = E2.range_geometry().allocate('random_int',symmetry=True)
- 
-    
-    LHS1 = (E2.direct(u2) * w2).sum()
-    RHS1 = (u2 * E2.adjoint(w2)).sum()
-    
-    numpy.testing.assert_equal(LHS1, RHS1)      
-    
-    out = E1.range_geometry().allocate()
-    E1.direct(u1, out=out)
-    a1 = E1.direct(u1)
-    numpy.testing.assert_array_equal(a1[0].as_array(), out[0].as_array()) 
-    numpy.testing.assert_array_equal(a1[1].as_array(), out[1].as_array()) 
-    numpy.testing.assert_array_equal(a1[2].as_array(), out[2].as_array()) 
-    numpy.testing.assert_array_equal(a1[3].as_array(), out[3].as_array()) 
-    
-    
-    out1 = E1.domain_geometry().allocate()
-    E1.adjoint(w1, out=out1)
-    b1 = E1.adjoint(w1)    
-    
-    LHS_out = (out * w1).sum()
-    RHS_out = (u1 * out1).sum()
-    print(LHS_out, RHS_out)
-    
-    
-    out2 = E2.range_geometry().allocate()
-    E2.direct(u2, out=out2)
-    a2 = E2.direct(u2)
-    
-    out21 = E2.domain_geometry().allocate()
-    E2.adjoint(w2, out=out21)
-    b2 = E2.adjoint(w2)    
-    
-    LHS_out = (out2 * w2).sum()
-    RHS_out = (u2 * out21).sum()
-    print(LHS_out, RHS_out)    
-    
-    
-    out = E1.range_geometry().allocate()
-    E1.direct(u1, out=out)
-    E1.adjoint(out, out=out1)
-    
-    print(E1.norm())
-    print(E2.norm())
-    
-  
+    print(E3.domain_geometry().shape, E3.range_geometry().shape)
+    u3 = E3.domain_geometry().allocate('random_int')
+    w3 = E3.range_geometry().allocate('random_int', symmetry = True)
+#    
+    lhs3 = E3.direct(u3).dot(w3)
+    rhs3 = u3.dot(E3.adjoint(w3))
+    np.testing.assert_almost_equal(lhs3, rhs3)  

--- a/Wrappers/Python/test/test_algorithms.py
+++ b/Wrappers/Python/test/test_algorithms.py
@@ -123,7 +123,7 @@ class TestAlgorithms(unittest.TestCase):
 	#### it seems FISTA does not work with Nowm2Sq
         # norm2sq = Norm2Sq(identity, b)
         # norm2sq.L = 2 * norm2sq.c * identity.norm()**2
-        norm2sq = FunctionOperatorComposition(L2NormSquared(b=b), identity)
+        norm2sq = FunctionOperatorComposition(L2NormSquared(b), identity)
         opt = {'tol': 1e-4, 'memopt':False}
         print ("initial objective", norm2sq(x_init))
         alg = FISTA(x_init=x_init, f=norm2sq, g=ZeroFunction())
@@ -227,11 +227,11 @@ class TestAlgorithms(unittest.TestCase):
                 alpha = .3
                 # fidelity
             if noise == 's&p':
-                g = L1Norm(b=noisy_data)
+                g = L1Norm(noisy_data)
             elif noise == 'poisson':
                 g = KullbackLeibler(noisy_data)
             elif noise == 'gaussian':
-                g = 0.5 * L2NormSquared(b=noisy_data)
+                g = 0.5 * L2NormSquared(noisy_data)
             return noisy_data, alpha, g
 
         noisy_data, alpha, g = setup(data, noise)
@@ -334,20 +334,20 @@ class TestAlgorithms(unittest.TestCase):
         def KL_Prox_PosCone(x, tau, out=None):
                 
             if out is None: 
-                tmp = 0.5 *( (x - fid.bnoise - tau) + ( (x + fid.bnoise - tau)**2 + 4*tau*fid.b   ) .sqrt() )
+                tmp = 0.5 *( (x - fid.background_term - tau) + ( (x + fid.background_term - tau)**2 + 4*tau*fid.data   ) .sqrt() )
                 return tmp.maximum(0)
             else:            
-                tmp =  0.5 *( (x - fid.bnoise - tau) + 
-                            ( (x + fid.bnoise - tau)**2 + 4*tau*fid.b   ) .sqrt()
+                tmp =  0.5 *( (x - fid.background_term - tau) + 
+                            ( (x + fid.background_term - tau)**2 + 4*tau*fid.data   ) .sqrt()
                             )
-                x.add(fid.bnoise, out=out)
+                x.add(fid.background_term, out=out)
                 out -= tau
                 out *= out
-                tmp = fid.b * (4 * tau)
+                tmp = fid.data * (4 * tau)
                 out.add(tmp, out=out)
                 out.sqrt(out=out)
                 
-                x.subtract(fid.bnoise, out=tmp)
+                x.subtract(fid.background_term, out=tmp)
                 tmp -= tau
                 
                 out += tmp

--- a/Wrappers/Python/test/test_functions.py
+++ b/Wrappers/Python/test/test_functions.py
@@ -88,7 +88,7 @@ class TestFunction(unittest.TestCase):
         d = ag.allocate(ImageGeometry.RANDOM_INT)
         alpha = 0.5
         # scaled function
-        g = alpha * L2NormSquared(b=noisy_data)
+        g = alpha * L2NormSquared(noisy_data)
         
         # Compare call of g
         a2 = alpha*(d - noisy_data).power(2).sum()
@@ -120,7 +120,7 @@ class TestFunction(unittest.TestCase):
         numpy.testing.assert_equal(f(u), u.squared_norm())
 
         # check grad/call with data
-        f1 = L2NormSquared(b=b)
+        f1 = L2NormSquared(b)
         b1 = f1.gradient(u)
         b2 = 2 * (u-b)
             
@@ -165,7 +165,7 @@ class TestFunction(unittest.TestCase):
         # scalar 
         scalar = 100
         f_scaled_no_data = scalar * L2NormSquared()
-        f_scaled_data = scalar * L2NormSquared(b=b)
+        f_scaled_data = scalar * L2NormSquared(b)
         
         # call
         numpy.testing.assert_equal(f_scaled_no_data(u), scalar*f(u))
@@ -215,7 +215,7 @@ class TestFunction(unittest.TestCase):
         #numpy.testing.assert_equal(f(u), u.squared_norm())
 
         # check grad/call with data
-        f1 = L2NormSquared(b=b)
+        f1 = L2NormSquared(b)
         b1 = f1.gradient(u)
         b2 = b1 * 0.
         f1.gradient(u, out=b2)
@@ -256,7 +256,7 @@ class TestFunction(unittest.TestCase):
         # scalar 
         scalar = 100
         f_scaled_no_data = scalar * L2NormSquared()
-        f_scaled_data = scalar * L2NormSquared(b=b)
+        f_scaled_data = scalar * L2NormSquared(b)
         
         # grad
         w = f_scaled_no_data.gradient(u)
@@ -305,7 +305,7 @@ class TestFunction(unittest.TestCase):
         
         A = 0.5 * Identity(ig)
         old_chisq = Norm2Sq(A, b, 1.0)
-        new_chisq = FunctionOperatorComposition(L2NormSquared(b=b),A)
+        new_chisq = FunctionOperatorComposition(L2NormSquared(b),A)
 
         yold = old_chisq(u)
         ynew = new_chisq(u)
@@ -358,7 +358,7 @@ class TestFunction(unittest.TestCase):
         
         out = ig.allocate()
         
-        f = KullbackLeibler(data, bnoise=bnoise)
+        f = KullbackLeibler(data, background_term = bnoise)
         
         grad = f.gradient(x)
         f.gradient(x, out=out)


### PR DESCRIPTION
IWhen we define the functions above, we write

``` python

f1 = L2NormSquared(b=data) 

```
in [here](https://github.com/vais-ral/CCPi-Framework/blob/master/Wrappers/Python/ccpi/optimisation/functions/L2NormSquared.py#L42)
``` python
f2 = L1Norm(b=data) 
```
in [here](https://github.com/vais-ral/CCPi-Framework/blob/master/Wrappers/Python/ccpi/optimisation/functions/L1Norm.py#L43)

``` python
f2 = KullbackLeibler(data)
```
 in [here](https://github.com/vais-ral/CCPi-Framework/blob/master/Wrappers/Python/ccpi/optimisation/functions/KullbackLeibler.py#L47)

Suggest to edit the __init__ method for all three.