### PR TITLE
override the dimension parameter, set angles to None by default

### DIFF
--- a/Wrappers/Python/ccpi/framework/framework.py
+++ b/Wrappers/Python/ccpi/framework/framework.py
@@ -217,8 +217,8 @@ class AcquisitionGeometry(object):
     HORIZONTAL = 'horizontal'
     def __init__(self, 
                  geom_type, 
-                 dimension, 
-                 angles, 
+                 dimension=None, 
+                 angles=None, 
                  pixel_num_h=0, 
                  pixel_size_h=1, 
                  pixel_num_v=0, 
@@ -255,6 +255,15 @@ class AcquisitionGeometry(object):
         angles_format radians or degrees
         """
         self.geom_type = geom_type   # 'parallel' or 'cone'
+        # Override the parameter passed as dimension
+        # determine if the geometry is 2D or 3D
+        if pixel_num_v >= 1:
+            dimension = '3D'
+        elif pixel_num_v == 0:
+            dimension = '2D'
+        else:
+            raise ValueError('Number of pixels at detector on the vertical axis must be >= 0. Got {}'.format(vert))
+    
         self.dimension = dimension # 2D or 3D
         if isinstance(angles, numpy.ndarray):
             self.angles = angles


### PR DESCRIPTION
Changed the signature of the `__init__` of `AcquisitionGeometry`

```python

def __init__(self, 
                 geom_type, 
                 dimension=None, 
                 angles=None, 
                 pixel_num_h=0, 
                 pixel_size_h=1, 
                 pixel_num_v=0, 
                 pixel_size_v=1, 
                 dist_source_center=None, 
                 dist_center_detector=None, 
                 channels=1,
                 **kwargs
                 )
```
The main change is that `dimension` and `angles` are now passed as `None` by default. 
`dimension` is being calculated by the other parameters as in [astra](https://github.com/vais-ral/CCPi-astra/blob/master/Wrappers/Python/ccpi/astra/utils/convert_geometry_to_astra.py#L15), so anything put there is overridden.

```python
if pixel_num_v >= 1:
    dimension = '3D'
elif pixel_num_v == 0:
    dimension = '2D'
else:
    raise ValueError('Number of pixels at detector on the vertical axis must be >= 0. Got {}'.format(vert))
    
```

The `angle` parameter is mandatory to be a numpy array as before, but passed as `None` to avoid the problem of removing the positional argument `dimension` which came before it.  