### PR TITLE
temporary disable checks of the column and row compatibility

### DIFF
--- a/Wrappers/Python/ccpi/optimisation/operators/BlockOperator.py
+++ b/Wrappers/Python/ccpi/optimisation/operators/BlockOperator.py
@@ -82,11 +82,18 @@ class BlockOperator(Operator):
             raise ValueError(
                     'Dimension and size do not match: expected {} got {}'
                     .format(n_elements,len(args)))
-        # test if operators are compatible
-        if not self.column_wise_compatible():
-            raise ValueError('Operators in each column must have the same domain')
-        if not self.row_wise_compatible():
-            raise ValueError('Operators in each row must have the same range')
+        # TODO
+        # until a decent way to check equality of Acquisition/Image geometries
+        # required to fullfil "Operators in a Block are required to have the same 
+        # domain column-wise and the same range row-wise."
+        # let us just not check if column/row-wise compatible, which is actually 
+        # the same achieved by the column_wise_compatible and row_wise_compatible methods.
+        
+        # # test if operators are compatible
+        # if not self.column_wise_compatible():
+        #     raise ValueError('Operators in each column must have the same domain')
+        # if not self.row_wise_compatible():
+        #     raise ValueError('Operators in each row must have the same range')
     
     def column_wise_compatible(self):
         '''Operators in a Block should have the same domain per column'''

--- a/Wrappers/Python/test/test_BlockOperator.py
+++ b/Wrappers/Python/test/test_BlockOperator.py
@@ -64,7 +64,7 @@ class TestBlockOperator(unittest.TestCase):
             ops = [ Identity(g) for g in ig ]
             
             K = BlockOperator(*ops)
-            self.assertTrue(False)
+            self.assertFalse(K.column_wise_compatible())
         except ValueError as ve:
             print (ve)
             self.assertTrue(True)
@@ -91,7 +91,7 @@ class TestBlockOperator(unittest.TestCase):
                 print ("range" , op.range_geometry().shape)
             for op in ops:
                 print ("domain" , op.domain_geometry().shape)
-            self.assertTrue(False)
+            self.assertTrue(K.row_wise_compatible())
         except ValueError as ve:
             print (ve)
             self.assertTrue(True)

--- a/Wrappers/Python/test/test_BlockOperator.py
+++ b/Wrappers/Python/test/test_BlockOperator.py
@@ -91,7 +91,7 @@ class TestBlockOperator(unittest.TestCase):
                 print ("range" , op.range_geometry().shape)
             for op in ops:
                 print ("domain" , op.domain_geometry().shape)
-            self.assertTrue(K.row_wise_compatible())
+            self.assertFalse(K.row_wise_compatible())
         except ValueError as ve:
             print (ve)
             self.assertTrue(True)


### PR DESCRIPTION
Following #516 this removes checks that are not well implemeted. The current code will then rely on Python's duck typing to fail at runtime if the `BlockOperator` are not compatible.