### PR TITLE
Add objective properties in PDHG

### DIFF
--- a/Wrappers/Python/ccpi/optimisation/algorithms/PDHG.py
+++ b/Wrappers/Python/ccpi/optimisation/algorithms/PDHG.py
@@ -163,3 +163,16 @@ class PDHG(Algorithm):
         d1 = -(self.f.convex_conjugate(self.y) + self.g.convex_conjugate(-1*self.operator.adjoint(self.y)))
 
         self.loss.append([p1, d1, p1-d1])
+        
+    @property
+    def objective(self):
+        '''alias of loss'''
+        return list(map(lambda x: x[0], self.loss))
+
+    @property
+    def dual_objective(self):
+        return list(map(lambda x: x[1], self.loss))
+    
+    @property
+    def primal_dual_gap(self):
+        return list(map(lambda x: x[2], self.loss))

--- a/Wrappers/Python/ccpi/optimisation/algorithms/PDHG.py
+++ b/Wrappers/Python/ccpi/optimisation/algorithms/PDHG.py
@@ -167,12 +167,12 @@ class PDHG(Algorithm):
     @property
     def objective(self):
         '''alias of loss'''
-        return list(map(lambda x: x[0], self.loss))
+        return [x[0] for x in self.loss]
 
     @property
     def dual_objective(self):
-        return list(map(lambda x: x[1], self.loss))
+        return [x[1] for x in self.loss]
     
     @property
     def primal_dual_gap(self):
-        return list(map(lambda x: x[2], self.loss))
+        return [x[2] for x in self.loss]


### PR DESCRIPTION
This adds three properties `objective`, `dual_objective` and `primal_dual_gap` to the `PDHG` algorithm. This makes `objective` consistent with other algorithms so that convergence plots can be made in an easy consistent way. Note that the `__loss` still holds `[p,d,p-d]` and the three new properties map from this.  `loss` is a property tied to `__loss` meaning that `loss` and `objective` are now no longer aliases for PDHG.

Builds locally and passes all tests, and very_verbose printing works.