### PR TITLE
Lipschitz constant as property

### DIFF
--- a/Wrappers/Python/ccpi/optimisation/functions/Function.py
+++ b/Wrappers/Python/ccpi/optimisation/functions/Function.py
@@ -34,7 +34,10 @@ class Function(object):
     """ Abstract class representing a function 
     
         :param L: Lipschitz constant of the gradient of the function F(x), when it is differentiable.
+        :type L: number, positive, default None
         :param domain: The domain of the function.
+
+        Lipschitz is positive real number, such that |f(x) - f(y)| <= L ||x-y||, assuming f: IG --> R
 
     """
     
@@ -144,22 +147,16 @@ class Function(object):
     
     @property
     def L(self):
-        if self._L is not None:
-            return self._L
-        else:
-            self.L = self.calculate_Lipschitz()
-            return self._L
+        '''Lipschitz is positive real number, such that |f(x) - f(y)| <= L ||x-y||, assuming f: IG --> R'''
+        return self._L
         # return self._L
     @L.setter
     def L(self, value):
         '''Setter for Lipschitz constant'''
-        if isinstance(value, (Number,)):
+        if isinstance(value, (Number,)) and value >= 0:
             self._L = value
         else:
-            raise TypeError('The Lipschitz constant is a real number')
-
-    def calculate_Lipschitz(self):
-        raise NotImplementedError('calculate_Lipschitz method not implemented')
+            raise TypeError('The Lipschitz constant is a real positive number')
     
 class SumFunction(Function):
     
@@ -233,8 +230,10 @@ class ScaledFunction(Function):
         self.function = function       
     @property
     def L(self):
-        #if function.L is not None:        
-        return abs(self.scalar) * self.function.L
+        if self.function.L is not None:
+            return abs(self.scalar) * self.function.L
+        else:
+            return None
 
     @property
     def scalar(self):
@@ -407,6 +406,9 @@ class ConstantFunction(Function):
         if not isinstance (value, Number):
             raise TypeError('expected scalar: got {}'.format(type(constant)))
         self._constant = value
+    @property
+    def L(self):
+        return 0.
 
 class ZeroFunction(ConstantFunction):
     

--- a/Wrappers/Python/ccpi/optimisation/functions/Function.py
+++ b/Wrappers/Python/ccpi/optimisation/functions/Function.py
@@ -173,15 +173,20 @@ class SumFunction(Function):
         super(SumFunction, self).__init__()        
 
         self.function1 = function1
-        self.function2 = function2               
+        self.function2 = function2
     @property
     def L(self):
         '''Lipschitz constant'''
-        # if function1.L is not None and function2.L is not None:
-        #     self.L = function1.L + function2.L
-        
-        return self.function1.L + self.function2.L
-        
+        if self.function1.L is not None and self.function2.L is not None:
+            self._L = self.function1.L + self.function2.L
+        else:
+            self._L = None
+        return self._L
+    @L.setter
+    def L(self, value):
+        # call base class setter
+        super(SumFunction, self.__class__).L.fset(self, value )
+
     def __call__(self,x):
         r"""Returns the value of the sum of functions :math:`F_{1}` and :math:`F_{2}` at x
         
@@ -236,6 +241,10 @@ class ScaledFunction(Function):
             return abs(self.scalar) * self.function.L
         else:
             return None
+    @L.setter
+    def L(self, value):
+        # call base class setter
+        super(SumFunction, self.__class__).L.fset(self, value )
 
     @property
     def scalar(self):

--- a/Wrappers/Python/ccpi/optimisation/functions/Function.py
+++ b/Wrappers/Python/ccpi/optimisation/functions/Function.py
@@ -37,7 +37,7 @@ class Function(object):
         :type L: number, positive, default None
         :param domain: The domain of the function.
 
-        Lipschitz is positive real number, such that |f(x) - f(y)| <= L ||x-y||, assuming f: IG --> R
+        Lipschitz of the gradient of the function; it is a positive real number, such that |f'(x) - f'(y)| <= L ||x-y||, assuming f: IG --> R
 
     """
     
@@ -147,7 +147,9 @@ class Function(object):
     
     @property
     def L(self):
-        '''Lipschitz is positive real number, such that |f(x) - f(y)| <= L ||x-y||, assuming f: IG --> R'''
+        '''Lipschitz of the gradient of function f.
+        
+        L is positive real number, such that |f'(x) - f'(y)| <= L ||x-y||, assuming f: IG --> R'''
         return self._L
         # return self._L
     @L.setter

--- a/Wrappers/Python/ccpi/optimisation/functions/Function.py
+++ b/Wrappers/Python/ccpi/optimisation/functions/Function.py
@@ -237,14 +237,16 @@ class ScaledFunction(Function):
         self.function = function       
     @property
     def L(self):
-        if self.function.L is not None:
-            return abs(self.scalar) * self.function.L
-        else:
-            return None
+        if self._L is None:
+            if self.function.L is not None:
+                self._L = abs(self.scalar) * self.function.L
+            else:
+                self._L = None
+        return self._L
     @L.setter
     def L(self, value):
         # call base class setter
-        super(SumFunction, self.__class__).L.fset(self, value )
+        super(ScaledFunction, self.__class__).L.fset(self, value )
 
     @property
     def scalar(self):
@@ -344,9 +346,19 @@ class SumFunctionScalar(SumFunction):
                         
         """                
         return self.function.proximal(x, tau, out=out)        
-            
-#    def function(self):       
-#       return self.function    
+    
+    @property
+    def L(self):
+        if self._L is None:
+            if self.function.L is not None:
+                self._L = self.function.L
+            else:
+                self._L = None
+        return self._L
+    @L.setter
+    def L(self, value):
+        # call base class setter
+        super(SumFunctionScalar, self.__class__).L.fset(self, value )
 
 class ConstantFunction(Function):
     

--- a/Wrappers/Python/ccpi/optimisation/functions/FunctionOperatorComposition.py
+++ b/Wrappers/Python/ccpi/optimisation/functions/FunctionOperatorComposition.py
@@ -50,25 +50,26 @@ class FunctionOperatorComposition(Function):
     :type f: :code:`Function`
     '''
 
-        super(FunctionOperatorComposition, self).__init__(L=None)
+        super(FunctionOperatorComposition, self).__init__()
+        
+        if not isinstance(function, Function):
+            raise ValueError('{} is not function '.format(type(self.function)))
+
+        if not isinstance(operator, Operator):
+            raise ValueError('{} is not function '.format(type(self.operator)))            
         
         self.function = function     
         self.operator = operator
-        
-        if not isinstance(self.function, Function):
-            raise ValueError('{} is not function '.format(type(self.function)))
-          
-        # check also ScaledOperator because it's not a child atm of Operator            
-        if not isinstance(self.operator, (Operator, ScaledOperator)):
-            raise ValueError('{} is not function '.format(type(self.operator)))            
-        
-        if self.L is None:
+
+    @property
+    def L(self):
+        if self._L is None:
             try:
-                self.L = function.L * operator.norm()**2 
+                return self.function.L * self.operator.norm()**2 
             except ValueError as er:
-                self.L = None
+                self._L = None
                 warnings.warn("Lipschitz constant was not calculated")
-        
+    
     def __call__(self, x):
         
         """ Returns :math:`F(Ax)`

--- a/Wrappers/Python/ccpi/optimisation/functions/FunctionOperatorComposition.py
+++ b/Wrappers/Python/ccpi/optimisation/functions/FunctionOperatorComposition.py
@@ -65,10 +65,10 @@ class FunctionOperatorComposition(Function):
     def L(self):
         if self._L is None:
             try:
-                return self.function.L * self.operator.norm()**2 
-            except ValueError as er:
+                self._L = self.function.L  * (self.operator.norm() ** 2)
+            except ValueError as ve:
                 self._L = None
-                warnings.warn("Lipschitz constant was not calculated")
+        return self._L
     
     def __call__(self, x):
         

--- a/Wrappers/Python/ccpi/optimisation/functions/L1Norm.py
+++ b/Wrappers/Python/ccpi/optimisation/functions/L1Norm.py
@@ -119,6 +119,10 @@ class L1Norm(Function):
             else:
                 out.fill(self.shinkage_operator(x, tau))
                                     
+    @property
+    def L(self):
+        '''Function not differentiable so doesn't have Lipschitz'''
+        raise ValueError('L1Norm does not have a Lipschitz constant')
 #    def proximal_conjugate(self, x, tau, out=None):
 #        
 #        r'''Proximal operator of the convex conjugate of L1Norm at x:

--- a/Wrappers/Python/ccpi/optimisation/functions/L1Norm.py
+++ b/Wrappers/Python/ccpi/optimisation/functions/L1Norm.py
@@ -119,10 +119,7 @@ class L1Norm(Function):
             else:
                 out.fill(self.shinkage_operator(x, tau))
                                     
-    @property
-    def L(self):
-        '''Function not differentiable so doesn't have Lipschitz'''
-        raise ValueError('L1Norm does not have a Lipschitz constant')
+    
 #    def proximal_conjugate(self, x, tau, out=None):
 #        
 #        r'''Proximal operator of the convex conjugate of L1Norm at x:

--- a/Wrappers/Python/ccpi/optimisation/functions/L2NormSquared.py
+++ b/Wrappers/Python/ccpi/optimisation/functions/L2NormSquared.py
@@ -157,24 +157,6 @@ class L2NormSquared(Function):
             else:
                 x.divide((1+2*tau), out=out)
 
-    
-#    def proximal_conjugate(self, x, tau, out=None):
-#        
-#        r'''Proximal operator of the convex conjugate of L2NormSquared at x:
-#           
-#           .. math::  prox_{\tau * f^{*}}(x)'''
-#        
-#        if out is None:
-#            if self.b is not None:
-#                return (x - tau*self.b)/(1 + tau/2) 
-#            else:
-#                return x/(1 + tau/2)
-#        else:
-#            if self.b is not None:
-#                x.subtract(tau*self.b, out=out)
-#                out.divide(1+tau/2, out=out)
-#            else:
-#                x.divide(1 + tau/2, out=out)                                        
 
 if __name__ == '__main__':
     

--- a/Wrappers/Python/ccpi/optimisation/functions/LeastSquares.py
+++ b/Wrappers/Python/ccpi/optimisation/functions/LeastSquares.py
@@ -53,22 +53,6 @@ class LeastSquares(Function):
         self.b = b  # Default zero DataSet?
         self.c = c  # Default 1.
         self.range_tmp = A.range_geometry().allocate()
-
-        # Compute the Lipschitz parameter from the operator if possible
-        # Leave it initialised to None otherwise
-        try:
-            self.L = 2.0*self.c*(self.A.norm()**2)
-        except AttributeError as ae:
-            if self.A.is_linear():
-                Anorm = LinearOperator.PowerMethod(self.A, 10)[0]
-                self.L = 2.0 * self.c * (Anorm*Anorm)
-            else:
-                warnings.warn('{} could not calculate Lipschitz Constant. {}'.format(
-                self.__class__.__name__, ae))
-            
-        except NotImplementedError as noe:
-            warnings.warn('{} could not calculate Lipschitz Constant. {}'.format(
-                self.__class__.__name__, noe))
         
     def __call__(self, x):
         
@@ -107,7 +91,22 @@ class LeastSquares(Function):
         else:
             return (2.0*self.c)*self.A.adjoint(self.A.direct(x) - self.b)
         
-
+    def calculate_Lipschitz(self):
+        # Compute the Lipschitz parameter from the operator if possible
+        # Leave it initialised to None otherwise
+        try:
+            return  2.0*self.c*(self.A.norm()**2)
+        except AttributeError as ae:
+            if self.A.is_linear():
+                Anorm = LinearOperator.PowerMethod(self.A, 10)[0]
+                return 2.0 * self.c * (Anorm*Anorm)
+            else:
+                warnings.warn('{} could not calculate Lipschitz Constant. {}'.format(
+                self.__class__.__name__, ae))
+            
+        except NotImplementedError as noe:
+            warnings.warn('{} could not calculate Lipschitz Constant. {}'.format(
+                self.__class__.__name__, noe))
     
     
     

--- a/Wrappers/Python/ccpi/optimisation/functions/MixedL21Norm.py
+++ b/Wrappers/Python/ccpi/optimisation/functions/MixedL21Norm.py
@@ -89,23 +89,21 @@ class MixedL21Norm(Function):
         where the convention 0 · (0/0) = 0 is used.
         
         """
-        
+
         if out is None:
-            
-        
             tmp = x.pnorm(2)
             res = (tmp - tau).maximum(0.0) * x/tmp
-            
+
             # TODO avoid using numpy, add operation in the framework
             # This will be useful when we add cupy 
                                  
             for el in res.containers:
-                
+
                 elarray = el.as_array()
                 elarray[np.isnan(elarray)]=0
-                el.fill(elarray)                                       
-            
-            return res            
+                el.fill(elarray)
+
+            return res
             
         else:
             
@@ -121,32 +119,8 @@ class MixedL21Norm(Function):
                 elarray[np.isnan(elarray)]=0
                 el.fill(elarray)  
 
-            out.fill(out)              
-                    
-# TODO, add the prox conjugate in the documenataion and then delete the code below            
-##############################################################################
-##############################################################################
-#    def proximal_conjugate(self, x, tau, out=None): 
-#
-#        
-#        if out is None:                                        
-#            tmp = x.get_item(0) * 0	
-#            for el in x.containers:	
-#                tmp += el.power(2.)	
-#            tmp.sqrt(out=tmp)	
-#            tmp.maximum(1.0, out=tmp)	
-#            frac = [ el.divide(tmp) for el in x.containers ]	
-#            return BlockDataContainer(*frac)
-#        
-#    
-#        else:
-#                            
-#            res1 = functools.reduce(lambda a,b: a + b*b, x.containers, x.get_item(0) * 0 )
-#            res1.sqrt(out=res1)	
-#            res1.maximum(1.0, out=res1)	
-#            x.divide(res1, out=out)
-                              
-                
+            out.fill(out)
+
 class SmoothMixedL21Norm(Function):
     
     """ SmoothMixedL21Norm function: :math:`F(x) = ||x||_{2,1} = \sum |x|_{2} = \sum \sqrt{ (x^{1})^{2} + (x^{2})^{2} + \epsilon^2 + \dots}`                  
@@ -164,7 +138,7 @@ class SmoothMixedL21Norm(Function):
         :param epsilon: smoothing parameter making MixedL21Norm differentiable 
         '''
 
-        super(SmoothMixedL21Norm, self).__init__(L=1)          
+        super(SmoothMixedL21Norm, self).__init__(L=1)
         self.epsilon = epsilon   
                 
         if self.epsilon==0:
@@ -172,7 +146,7 @@ class SmoothMixedL21Norm(Function):
                             
     def __call__(self, x):
         
-        r"""Returns the value of the SmoothMixedL21Norm function at x.                                            
+        r"""Returns the value of the SmoothMixedL21Norm function at x.
         """
         if not isinstance(x, BlockDataContainer):
             raise ValueError('__call__ expected BlockDataContainer, got {}'.format(type(x))) 
@@ -199,30 +173,3 @@ class SmoothMixedL21Norm(Function):
             return x.divide(denom)
         else:
             x.divide(denom, out=out)        
-
-
-
-
-
-    
-    
-    
-    
-    
-    
-    
-    
-    
-
-      
-    
-    
-
-      
-    
-    
-    
-
-    
-
-    

--- a/Wrappers/Python/ccpi/optimisation/functions/Rosenbrock.py
+++ b/Wrappers/Python/ccpi/optimisation/functions/Rosenbrock.py
@@ -23,7 +23,6 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-from __future__ import unicode_literals
 import numpy
 from ccpi.optimisation.functions import Function
 from ccpi.framework import VectorData, VectorGeometry

--- a/Wrappers/Python/test/test_SumFunction.py
+++ b/Wrappers/Python/test/test_SumFunction.py
@@ -133,27 +133,29 @@ class TestFunction(unittest.TestCase):
             
         print('###################  Check Lispchitz constant ################## \n')
         
-        for func in list1:
+        for i,func in enumerate(list1):
             
             if isinstance(func, ScaledFunction):
                 type_fun = ' scalar * ' + type(func.function).__name__
             else:    
                 type_fun = type(func).__name__            
                
-            
-            # check Lispchitz sum of two functions  
-            
-            if isinstance(func, Number):
-                tmp_fun_L = 0
-            else:
-                tmp_fun_L = func.L           
-            
-            sumf = f1 + func   
-            
             try:
-                sumf.L==f1.L + tmp_fun_L
-            except TypeError:
-                print('Function {} has L = None'.format(type_fun))
+                # check Lispchitz sum of two functions  
+                print ("i", i,func.__class__.__name__)
+                if isinstance(func, Number):
+                    tmp_fun_L = 0
+                else:
+                    tmp_fun_L = func.L           
+                
+                sumf = f1 + func   
+                
+                try:
+                    sumf.L==f1.L + tmp_fun_L
+                except TypeError:
+                    print('Function {} has L = None'.format(type_fun))
+            except ValueError as nie:
+                print (func.__class__.__name__, nie)
                 
         print('\n###################  Check Gradient ################## \n')   
               

--- a/Wrappers/Python/test/test_algorithms.py
+++ b/Wrappers/Python/test/test_algorithms.py
@@ -222,7 +222,7 @@ class TestAlgorithms(unittest.TestCase):
         x_init = ImageData(geometry=ig)
         x_init = ig.allocate()
         b = x_init.copy()
-        # fill with random numbers
+        # fill with random numbers  
         b.fill(numpy.random.random(x_init.shape))
         x_init = ig.allocate(ImageGeometry.RANDOM)
         identity = Identity(ig)
@@ -230,13 +230,13 @@ class TestAlgorithms(unittest.TestCase):
 	    #### it seems FISTA does not work with Nowm2Sq
         norm2sq = LeastSquares(identity, b)
         print ('Lipschitz', norm2sq.L)
-        norm2sq.L = None
+        # norm2sq.L = None
         #norm2sq.L = 2 * norm2sq.c * identity.norm()**2
         #norm2sq = FunctionOperatorComposition(L2NormSquared(b=b), identity)
         opt = {'tol': 1e-4, 'memopt':False}
         print ("initial objective", norm2sq(x_init))
         try:
-            alg = FISTA(x_init=x_init, f=norm2sq, g=ZeroFunction())
+            alg = FISTA(x_init=x_init, f=L1Norm(), g=ZeroFunction())
             self.assertTrue(False)
         except ValueError as ve:
             print (ve)

--- a/Wrappers/Python/test/test_functions.py
+++ b/Wrappers/Python/test/test_functions.py
@@ -22,7 +22,7 @@ import numpy as np
 from ccpi.framework import DataContainer, ImageGeometry, \
     VectorGeometry, VectorData, BlockDataContainer
 from ccpi.optimisation.operators import Identity, LinearOperatorMatrix, CompositionOperator, DiagonalOperator, BlockOperator
-from ccpi.optimisation.functions import Function, KullbackLeibler
+from ccpi.optimisation.functions import Function, KullbackLeibler, ConstantFunction, TranslateFunction
 from ccpi.optimisation.operators import Gradient
 
 from ccpi.optimisation.functions import Function, KullbackLeibler, WeightedL2NormSquared, L2NormSquared,\
@@ -810,6 +810,43 @@ class TestFunction(unittest.TestCase):
         print (func2.L)
         func2.L = 2
         assert func2.L == 2
+    def test_Lipschitz2(self):
+        print('Test for test_Lipschitz2')         
+            
+        M, N = 50, 50
+        ig = ImageGeometry(voxel_num_x=M, voxel_num_y = N)
+        b = ig.allocate('random', seed=1)
+        
+        print('Check call with Identity operator... OK\n')
+        operator = 3 * Identity(ig)
+            
+        u = ig.allocate('random_int', seed = 50)
+        func2 = LeastSquares(operator, b, 0.5)
+        func1 = ConstantFunction(0.3)
+        f3 = func1 + func2
+        assert f3.L != 2
+        print (func2.L)
+        func2.L = 2
+        assert func2.L == 2
+    def test_Lipschitz3(self):
+        print('Test for test_Lipschitz3')         
+            
+        M, N = 50, 50
+        ig = ImageGeometry(voxel_num_x=M, voxel_num_y = N)
+        b = ig.allocate('random', seed=1)
+        
+        print('Check call with Identity operator... OK\n')
+        operator = 3 * Identity(ig)
+            
+        u = ig.allocate('random_int', seed = 50)
+        # func2 = LeastSquares(operator, b, 0.5)
+        func1 = ConstantFunction(0.3)
+        f3 = TranslateFunction(func1, 3)
+        assert f3.L != 2
+        print (f3.L)
+        f3.L = 2
+        assert f3.L == 2
+
 
 
 

--- a/Wrappers/Python/test/test_functions.py
+++ b/Wrappers/Python/test/test_functions.py
@@ -323,11 +323,16 @@ class TestFunction(unittest.TestCase):
         operator = 3 * Identity(ig)
             
         u = ig.allocate('random_int', seed = 50)
-        
-        func1 = FunctionOperatorComposition(0.5 * L2NormSquared(b = b), operator)
+        f = 0.5 * L2NormSquared(b = b)
+        func1 = FunctionOperatorComposition(f, operator)
         func2 = LeastSquares(operator, b, 0.5)
-        print("func1.L {}, func2.L {}, operator norm {}".format(func1.L, func2.L, operator.norm()))
-            
+        print("f.L {}".format(f.L))
+        print("0.5*f.L {}".format((0.5*f).L))
+        print("type func1 {}".format(type(func1)))
+        print("func1.L {}".format(func1.L))
+        print("func2.L {}".format(func2.L))
+        print("operator.norm() {}".format(operator.norm()))
+  
         self.assertNumpyArrayAlmostEqual(func1(u), func2(u))
         
         

--- a/Wrappers/Python/test/test_functions.py
+++ b/Wrappers/Python/test/test_functions.py
@@ -481,6 +481,26 @@ class TestFunction(unittest.TestCase):
         a = ib(im)
         numpy.testing.assert_equal(a, numpy.inf)
 
+    def test_Lipschitz(self):
+        print('Test for FunctionOperatorComposition')         
+            
+        M, N = 50, 50
+        ig = ImageGeometry(voxel_num_x=M, voxel_num_y = N)
+        b = ig.allocate('random', seed=1)
+        
+        print('Check call with Identity operator... OK\n')
+        operator = 3 * Identity(ig)
+            
+        u = ig.allocate('random_int', seed = 50)
+        func2 = LeastSquares(operator, b, 0.5)
+        assert func2.L != 2
+        print (func2.L)
+        func2.L = 2
+        assert func2.L == 2
+
+
+
+
 if __name__ == '__main__':
     
     d = TestFunction()

--- a/Wrappers/Python/test/test_functions.py
+++ b/Wrappers/Python/test/test_functions.py
@@ -846,6 +846,46 @@ class TestFunction(unittest.TestCase):
         print (f3.L)
         f3.L = 2
         assert f3.L == 2
+    def test_Lipschitz4(self):
+        print('Test for test_Lipschitz4')         
+            
+        M, N = 50, 50
+        ig = ImageGeometry(voxel_num_x=M, voxel_num_y = N)
+        b = ig.allocate('random', seed=1)
+        
+        print('Check call with Identity operator... OK\n')
+        operator = 3 * Identity(ig)
+            
+        u = ig.allocate('random_int', seed = 50)
+        # func2 = LeastSquares(operator, b, 0.5)
+        func1 = ConstantFunction(0.3)
+        f3 = func1 + 3
+        assert f3.L == 0
+        print ("OK")
+        print (f3.L)
+        f3.L = 2
+        assert f3.L == 2
+        print ("OK")
+        assert func1.L == 0
+        print ("OK")
+        try:
+            func1.L = 2
+            assert False
+        except AttributeError as ve:
+            assert True
+        print ("OK")
+        f2 = LeastSquares(operator, b, 0.5)
+        f4 = 2 * f2
+        assert f4.L == 2 * f2.L
+        
+        print ("OK")
+        f4.L = 10
+        assert f4.L != 2 * f2.L  
+        print ("OK")
+
+        f4 = -2 * f2
+        assert f4.L == 2 * f2.L
+        
 
 
 

--- a/src/Core/CMakeLists.txt
+++ b/src/Core/CMakeLists.txt
@@ -10,6 +10,11 @@ if (WIN32)
 	set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /Ddll_EXPORTS")
 endif()
 
+if (${CMAKE_C_COMPILER_ID} STREQUAL "GNU")
+  # appends some flags
+  add_compile_options(-ftree-vectorize -fopt-info-vec-optimized -fopt-info-vec)
+  # add_compile_options(-march=native -mavx )
+endif()
 
 message("CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS}")
 message("CMAKE_C_FLAGS ${CMAKE_C_FLAGS}")


### PR DESCRIPTION
Adds the property `L` for the Lipschitz constant of the gradient of the function: 
`|f'(x) - f'(y)| <= L ||x-y||`

This will be 

1. `None` if the function is not differentiable
1. a real positive number

It is possible to set `L` to any real positive number and a basic type check is done. For `LeastSquares` a method to calculate it is provided, `calculate_Lipschitz`.

closes #559