### PR TITLE
Basic zeiss data reader and reconstruction example

### DIFF
--- a/Wrappers/Python/ccpi/io/TXRMDataReader.py
+++ b/Wrappers/Python/ccpi/io/TXRMDataReader.py
@@ -259,10 +259,15 @@ if __name__ == '__main__':
     plt.figure()
     plt.imshow(data.subset(angle=0).as_array())
     plt.colorbar()
+    plt.gray()
+    plt.savefig('walnut_proj0.png',dpi=300)
+    
     
     plt.figure()
     plt.imshow(data.subset(angle=800).as_array())
     plt.colorbar()
+    plt.gray()
+    plt.savefig('walnut_proj800.png',dpi=300)
     
     # Extract AcquisitionGeometry for central slice for 2D fanbeam reconstruction
     ag2d = AcquisitionGeometry('cone',
@@ -279,6 +284,8 @@ if __name__ == '__main__':
     plt.figure()
     plt.imshow(data2d.as_array())
     plt.colorbar()
+    plt.gray()
+    plt.savefig('walnut_sinotrans.png',dpi=300)
     
     data2d.log(out=data2d)
     data2d *= -1
@@ -286,6 +293,8 @@ if __name__ == '__main__':
     plt.figure()
     plt.imshow(data2d.as_array())
     plt.colorbar()
+    plt.gray()
+    plt.savefig('walnut_sinoabs.png',dpi=300)
     
     # Choose the number of voxels to reconstruct onto as number of detector pixels
     N = data.geometry.pixel_num_h
@@ -314,6 +323,9 @@ if __name__ == '__main__':
     
     plt.figure()
     plt.imshow(recfbp.as_array())
+    plt.gray()
+    plt.colorbar()
+    plt.savefig('walnut_2DFBP.png',dpi=300)
 
     '''
     # Set up the Projector (AcquisitionModel) using ASTRA on GPU

--- a/Wrappers/Python/ccpi/io/TXRMDataReader.py
+++ b/Wrappers/Python/ccpi/io/TXRMDataReader.py
@@ -15,15 +15,10 @@
 #   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 from ccpi.framework import AcquisitionData, AcquisitionGeometry
 import numpy
 import os
-
-import dxchange
 import olefile
     
         
@@ -46,7 +41,8 @@ class TXRMDataReader(object):
             self.set_up(txrm_file = self.txrm_file)
             
     def set_up(self, 
-               txrm_file = None):
+               txrm_file = None,
+               angle_unit = AcquisitionGeometry.DEGREE):
         
         self.txrm_file = txrm_file
         
@@ -56,9 +52,13 @@ class TXRMDataReader(object):
         # check if txrm file exists
         if not(os.path.isfile(self.txrm_file)):
             raise Exception('File\n {}\n does not exist.'.format(self.txrm_file))  
+        possible_units = [AcquisitionGeometry.DEGREE, AcquisitionGeometry.RADIAN]
+        if angle_unit in possible_units:
+            self.angle_unit = angle_unit
+        else:
+            raise ValueError('angle_unit should be one of {}'.format(possible_units))
 
     def get_geometry(self):
-        
         '''
         Return AcquisitionGeometry object
         '''
@@ -66,24 +66,26 @@ class TXRMDataReader(object):
         return self._ag
         
     def load_projections(self):
-        
         '''
         Load projections and return AcquisitionData container
         '''
-        
+        # the import will raise an ImportError if dxchange is not installed
+        import dxchange
         # Load projections and most metadata
         data, metadata = dxchange.read_txrm(self.txrm_file)
+        for k,v in metadata.items():
+            print (k,v)
         number_of_images = data.shape[0]
         
         # Read source to center and detector to center distances
-        ole = olefile.OleFileIO(self.txrm_file)
-        StoCdist = dxchange.reader._read_ole_arr(ole, \
-                'ImageInfo/StoRADistance', "<{0}f".format(number_of_images))
-        DtoCdist = dxchange.reader._read_ole_arr(ole, \
-                'ImageInfo/DtoRADistance', "<{0}f".format(number_of_images))
-        ole.close()
-        StoCdist = numpy.abs(StoCdist[0])
-        DtoCdist = numpy.abs(DtoCdist[0])
+        with olefile.OleFileIO(self.txrm_file) as ole:
+            StoRADistance = dxchange.reader._read_ole_arr(ole, \
+                    'ImageInfo/StoRADistance', "<{0}f".format(number_of_images))
+            DtoRADistance = dxchange.reader._read_ole_arr(ole, \
+                    'ImageInfo/DtoRADistance', "<{0}f".format(number_of_images))
+            
+        dist_source_center   = numpy.abs( StoRADistance[0] )
+        dist_center_detector = numpy.abs( DtoRADistance[0] )
         
         # normalise data by flatfield
         data = data / metadata['reference']
@@ -97,36 +99,46 @@ class TXRMDataReader(object):
         # Pixelsize loaded in metadata is really the voxel size in um.
         # We can compute the effective detector pixel size as the geometric
         # magnification times the voxel size.
-        d_pixel_size = ((StoCdist+DtoCdist)/StoCdist)*metadata['pixel_size']
+        d_pixel_size = ((dist_source_center+dist_center_detector)/dist_source_center)*metadata['pixel_size']
         
+        # convert angles to requested unit measure, Zeiss stores in radians
+        # AND convert direction of rotation from Zeiss to our convention
+        if self.angle_unit == AcquisitionGeometry.DEGREE:
+            angles = - numpy.degrees(metadata['thetas'])
+        else:
+            angles = - numpy.asarray(metadata['thetas'])
+
         self._ag = AcquisitionGeometry(geom_type = 'cone', 
                                        dimension = '3D', 
-                                       angles = numpy.degrees(metadata['thetas']), 
+                                       angles = angles, 
                                        pixel_num_h = metadata['image_width'], 
                                        pixel_size_h = d_pixel_size/1000, 
                                        pixel_num_v = metadata['image_height'], 
                                        pixel_size_v = d_pixel_size/1000, 
-                                       dist_source_center =  StoCdist, 
-                                       dist_center_detector = DtoCdist, 
+                                       dist_source_center =  dist_source_center, 
+                                       dist_center_detector = dist_center_detector, 
                                        channels = 1,
-                                       angle_unit = 'degree')
+                                       angle_unit = self.angle_unit,
+                                       dimension_labels = ['angle', \
+                                                           'vertical', \
+                                                           'horizontal'])
+        acq_data = self._ag.allocate(None)
+        acq_data.fill(data)
 
-        return AcquisitionData(array = data, 
-                               deep_copy = False,
-                               geometry = self._ag,
-                               dimension_labels = ['angle', \
-                                                   'vertical', \
-                                                   'horizontal'])
-                
+        return acq_data
+
 if __name__ == '__main__':
     
     from ccpi.framework import ImageGeometry
     from ccpi.astra.processors import FBP
     import matplotlib.pyplot as plt
     
-    filename = "/media/newhd/shared/Data/zeiss/walnut/valnut/valnut_2014-03-21_643_28/tomo-A/valnut_tomo-A.txrm"
+    angle_unit = AcquisitionGeometry.RADIAN
+    #filename = "/media/newhd/shared/Data/zeiss/walnut/valnut/valnut_2014-03-21_643_28/tomo-A/valnut_tomo-A.txrm"
+    filename = os.path.abspath("/home/edo/scratch/Dataset/CCPi/valnut_tomo-A.txrm")
     reader = TXRMDataReader()
-    reader.set_up(txrm_file=filename)
+    reader.set_up(txrm_file=filename, 
+                  angle_unit=angle_unit)
     
     data = reader.load_projections()
     
@@ -136,27 +148,37 @@ if __name__ == '__main__':
     plt.imshow(data.subset(angle=0).as_array())
     plt.colorbar()
     plt.gray()
-    plt.savefig('walnut_proj0.png',dpi=300)
+    # plt.savefig('walnut_proj0.png',dpi=300)
     
     
     plt.figure()
     plt.imshow(data.subset(angle=800).as_array())
     plt.colorbar()
     plt.gray()
-    plt.savefig('walnut_proj800.png',dpi=300)
+    # plt.savefig('walnut_proj800.png',dpi=300)
     
+    if angle_unit == AcquisitionGeometry.DEGREE:
+        dangles = numpy.pi/180*data.geometry.angles
+    else:
+        dangles = data.geometry.angles
     # Extract AcquisitionGeometry for central slice for 2D fanbeam reconstruction
     ag2d = AcquisitionGeometry('cone',
                           '2D',
-                          angles=-numpy.pi/180*data.geometry.angles,
+                          angles=dangles,
                           pixel_num_h=data.geometry.pixel_num_h,
                           pixel_size_h=data.geometry.pixel_size_h,
                           dist_source_center=data.geometry.dist_source_center, 
-                          dist_center_detector=data.geometry.dist_center_detector)
+                          dist_center_detector=data.geometry.dist_center_detector,
+                          angle_unit=angle_unit)
     
     # Set up AcquisitionData object for central slice 2D fanbeam
-    data2d = AcquisitionData(data.subset(vertical=512),geometry=ag2d)
-    
+    # data2d = AcquisitionData(data.subset(vertical=512),geometry=ag2d)
+    data2d = data.subset(vertical=512)
+
+    print ("data2d.geometry",data2d.geometry)
+    print ("ag2d", ag2d)
+
+    # exit(0)
     plt.figure()
     plt.imshow(data2d.as_array())
     plt.colorbar()
@@ -186,11 +208,17 @@ if __name__ == '__main__':
                          voxel_num_y=N,
                          voxel_size_x=voxel_size_h, 
                          voxel_size_y=voxel_size_h)
+    ig3d = ImageGeometry(voxel_num_x=N,
+                         voxel_num_y=N,
+                         voxel_num_z=N,
+                         voxel_size_x=voxel_size_h, 
+                         voxel_size_y=voxel_size_h,
+                         voxel_size_z=data.geometry.pixel_size_v / mag)
     
     print('done set up astra op')
     
     fbpalg = FBP(ig2d,ag2d)
-
+    #fbpalg = FBP(ig2d, data2d.geometry)
     fbpalg.set_input(data2d)
     
     recfbp = fbpalg.get_output()
@@ -200,4 +228,19 @@ if __name__ == '__main__':
     plt.gray()
     plt.colorbar()
     
+    shuffle = data.subset(dimensions=['vertical','angle','horizontal'])
+    shuffle.log(out=shuffle)
+    shuffle *= -1
+
+    fbp3d = FBP(ig3d, shuffle.geometry)
+    fbp3d.set_input(shuffle)
+    vol = fbp3d.get_output()
+    
+    plt.figure()
+    plt.imshow(vol.subset(vertical=512).as_array())
+    plt.gray()
+    plt.colorbar()
+    
+
+    plt.show()
     

--- a/Wrappers/Python/ccpi/io/TXRMDataReader.py
+++ b/Wrappers/Python/ccpi/io/TXRMDataReader.py
@@ -1,0 +1,317 @@
+# -*- coding: utf-8 -*-
+#  CCP in Tomographic Imaging (CCPi) Core Imaging Library (CIL).
+
+#   Copyright 2019 UKRI-STFC
+#   Copyright 2019 University of Manchester
+
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+
+#   http://www.apache.org/licenses/LICENSE-2.0
+
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+from ccpi.framework import AcquisitionData, AcquisitionGeometry
+import numpy
+import os
+
+import dxchange
+import olefile
+    
+        
+class TXRMDataReader(object):
+    
+    def __init__(self, 
+                 **kwargs):
+        '''
+        Constructor
+        
+        Input:
+            
+            txrm_file       full path to .txrm file
+                    
+        '''
+        
+        self.txrm_file = kwargs.get('txrm_file', None)
+        
+        if self.txrm_file is not None:
+            self.set_up(txrm_file = self.txrm_file)
+            
+    def set_up(self, 
+               txrm_file = None):
+        
+        self.txrm_file = txrm_file
+        
+        if self.txrm_file == None:
+            raise Exception('Path to txrm file is required.')
+        
+        # check if xtek file exists
+        if not(os.path.isfile(self.txrm_file)):
+            raise Exception('File\n {}\n does not exist.'.format(self.txrm_file))  
+                
+        '''        
+        # parse xtek file
+        with open(self.xtek_file, 'r') as f:
+            content = f.readlines()    
+                
+        content = [x.strip() for x in content]
+        
+        for line in content:
+            # filename of TIFF files
+            if line.startswith("Name"):
+                self._experiment_name = line.split('=')[1]
+            # number of projections
+            elif line.startswith("Projections"):
+                num_projections = int(line.split('=')[1])
+            # white level - used for normalization
+            elif line.startswith("WhiteLevel"):
+                self._white_level = float(line.split('=')[1])
+            # number of pixels along Y axis
+            elif line.startswith("DetectorPixelsY"):
+                pixel_num_v_0 = int(line.split('=')[1])
+            # number of pixels along X axis
+            elif line.startswith("DetectorPixelsX"):
+                pixel_num_h_0 = int(line.split('=')[1])
+            # pixel size along X axis
+            elif line.startswith("DetectorPixelSizeX"):
+                pixel_size_h_0 = float(line.split('=')[1])
+            # pixel size along Y axis
+            elif line.startswith("DetectorPixelSizeY"):
+                pixel_size_v_0 = float(line.split('=')[1])
+            # source to center of rotation distance
+            elif line.startswith("SrcToObject"):
+                source_x = float(line.split('=')[1])
+            # source to detector distance
+            elif line.startswith("SrcToDetector"):
+                detector_x = float(line.split('=')[1])
+            # initial angular position of a rotation stage
+            elif line.startswith("InitialAngle"):
+                initial_angle = float(line.split('=')[1])
+            # angular increment (in degrees)
+            elif line.startswith("AngularStep"):
+                angular_step = float(line.split('=')[1])
+                
+        if self.roi == -1:
+            self._roi_par = [(0, pixel_num_v_0), \
+                              (0, pixel_num_h_0)]
+        else:
+            self._roi_par = self.roi.copy()
+            if self._roi_par[0] == -1:
+                self._roi_par[0] = (0, pixel_num_v_0)
+            if self._roi_par[1] == -1:
+                self._roi_par[1] = (0, pixel_num_h_0)
+                
+        # calculate number of pixels and pixel size
+        if (self.binning == [1, 1]):
+            pixel_num_v = self._roi_par[0][1] - self._roi_par[0][0]
+            pixel_num_h = self._roi_par[1][1] - self._roi_par[1][0]
+            pixel_size_v = pixel_size_v_0
+            pixel_size_h = pixel_size_h_0
+        else:
+            pixel_num_v = (self._roi_par[0][1] - self._roi_par[0][0]) // self.binning[0]
+            pixel_num_h = (self._roi_par[1][1] - self._roi_par[1][0]) // self.binning[1]
+            pixel_size_v = pixel_size_v_0 * self.binning[0]
+            pixel_size_h = pixel_size_h_0 * self.binning[1]
+        '''
+        
+        '''
+        Parse the angles file .ang or _ctdata.txt file and returns the angles
+        as an numpy array. 
+        '''
+        '''
+        input_path = os.path.dirname(self.xtek_file)
+        angles_ctdata_file = os.path.join(input_path, '_ctdata.txt')
+        angles_named_file = os.path.join(input_path, self._experiment_name+'.ang')
+        angles = numpy.zeros(num_projections, dtype = 'float')
+        
+        # look for _ctdata.txt
+        if os.path.exists(angles_ctdata_file):
+            # read txt file with angles
+            with open(angles_ctdata_file) as f:
+                content = f.readlines()
+            # skip firt three lines
+            # read the middle value of 3 values in each line as angles in degrees
+            index = 0
+            for line in content[3:]:
+                angles[index] = float(line.split(' ')[1])
+                index += 1
+            angles = angles + initial_angle
+        
+        # look for ang file
+        elif os.path.exists(angles_named_file):
+            # read the angles file which is text with first line as header
+            with open(angles_named_file) as f:
+                content = f.readlines()
+            # skip first line
+            index = 0
+            for line in content[1:]:
+                angles[index] = float(line.split(':')[1])
+                index += 1
+            angles = numpy.flipud(angles + initial_angle) # angles are in the reverse order
+            
+        else:   # calculate angles based on xtek file
+            angles = initial_angle + angular_step * range(num_projections)
+        
+        # fill in metadata
+        self._ag = AcquisitionGeometry(geom_type = 'cone', 
+                                       dimension = '3D', 
+                                       angles = angles, 
+                                       pixel_num_h = pixel_num_h, 
+                                       pixel_size_h = pixel_size_h, 
+                                       pixel_num_v = pixel_num_v, 
+                                       pixel_size_v = pixel_size_v, 
+                                       dist_source_center = source_x, 
+                                       dist_center_detector = detector_x - source_x, 
+                                       channels = 1,
+                                       angle_unit = 'degree')
+        '''
+
+    #def get_geometry(self):
+    #    
+    #    '''
+    #    Return AcquisitionGeometry object
+    #    '''
+    #    
+    #    return self._ag
+        
+    def load_projections(self):
+        
+        '''
+        Load projections and return AcquisitionData container
+        '''
+        
+        # Load projections and most metadata
+        data, metadata = dxchange.read_txrm(self.txrm_file)
+        number_of_images = data.shape[0]
+        
+        # Read source to center and detector to center distances
+        ole = olefile.OleFileIO(self.txrm_file)
+        StoCdist = dxchange.reader._read_ole_arr(ole, \
+                'ImageInfo/StoRADistance', "<{0}f".format(number_of_images))
+        DtoCdist = dxchange.reader._read_ole_arr(ole, \
+                'ImageInfo/DtoRADistance', "<{0}f".format(number_of_images))
+        ole.close()
+        StoCdist = numpy.abs(StoCdist[0])
+        DtoCdist = numpy.abs(DtoCdist[0])
+        
+        # normalise data by flatfield
+        data = data / metadata['reference']
+        
+        # circularly shift data by rounded x and y shifts
+        for k in range(number_of_images):
+            data[k,:,:] = numpy.roll(data[k,:,:], \
+                (int(metadata['x-shifts'][k]),int(metadata['y-shifts'][k])), \
+                axis=(1,0))
+        
+        # Pixelsize loaded in metadata is really the voxel size in um.
+        # We can compute the effective detector pixel size as the geometric
+        # magnification times the voxel size.
+        d_pixel_size = ((StoCdist+DtoCdist)/StoCdist)*metadata['pixel_size']
+        
+        self._ag = AcquisitionGeometry(geom_type = 'cone', 
+                                       dimension = '3D', 
+                                       angles = numpy.degrees(metadata['thetas']), 
+                                       pixel_num_h = metadata['image_width'], 
+                                       pixel_size_h = d_pixel_size, 
+                                       pixel_num_v = metadata['image_height'], 
+                                       pixel_size_v = d_pixel_size, 
+                                       dist_source_center =  StoCdist, 
+                                       dist_center_detector = DtoCdist, 
+                                       channels = 1,
+                                       angle_unit = 'degree')
+        
+        
+        #if (self.normalize):
+        #    data /= self._white_level
+        #    data[data > 1] = 1
+
+        return AcquisitionData(array = data, 
+                               deep_copy = False,
+                               geometry = self._ag,
+                               dimension_labels = ['angle', \
+                                                   'vertical', \
+                                                   'horizontal'])
+                
+if __name__ == '__main__':
+    
+    from ccpi.framework import ImageGeometry, ImageData
+    from ccpi.astra.operators import AstraProjectorSimple
+    from ccpi.optimisation.algorithms import FISTA, CGLS
+    
+    filename = "/media/newhd/shared/Data/zeiss/walnut/valnut/valnut_2014-03-21_643_28/tomo-A/valnut_tomo-A.txrm"
+    reader = TXRMDataReader()
+    reader.set_up(txrm_file=filename)
+    
+    data = reader.load_projections()
+    
+    # Extract AcquisitionGeometry for central slice for 2D fanbeam reconstruction
+    ag2d = AcquisitionGeometry('cone',
+                          '2D',
+                          angles=data.geometry.angles,
+                          pixel_num_h=data.geometry.pixel_num_h,
+                          pixel_size_h=data.geometry.pixel_size_h,
+                          dist_source_center=data.geometry.dist_source_center, 
+                          dist_center_detector=data.geometry.dist_center_detector)
+    
+    # Set up AcquisitionData object for central slice 2D fanbeam
+    data2d = AcquisitionData(data.subset(vertical=512),geometry=ag2d)
+    
+    # Choose the number of voxels to reconstruct onto as number of detector pixels
+    N = data.geometry.pixel_num_h
+    
+    # Geometric magnification
+    mag = (numpy.abs(data.geometry.dist_center_detector) + \
+           numpy.abs(data.geometry.dist_source_center)) / \
+           numpy.abs(data.geometry.dist_source_center)
+           
+    # Voxel size is detector pixel size divided by mag
+    voxel_size_h = data.geometry.pixel_size_h / mag
+    
+    # Construct the appropriate ImageGeometry
+    ig2d = ImageGeometry(voxel_num_x=N,
+                         voxel_num_y=N,
+                         voxel_size_x=voxel_size_h, 
+                         voxel_size_y=voxel_size_h)
+    
+    # Set up the Projector (AcquisitionModel) using ASTRA on GPU
+    Aop = AstraProjectorSimple(ig2d, ag2d,"gpu")
+    
+    # Set initial guess for CGLS reconstruction
+    x_init = ImageData(geometry=ig2d)
+    
+    # Set tolerance and number of iterations for reconstruction algorithms.
+    opt = {'tol': 1e-4, 'iter': 50}
+    
+    # First a CGLS reconstruction can be done:
+    CGLS_alg = CGLS()
+    CGLS_alg.set_up(x_init, Aop, data2d)
+    CGLS_alg.max_iteration = 2000
+    CGLS_alg.run(opt['iter'])
+
+
+'''
+# usage example
+xtek_file = '/home/evelina/nikon_data/SophiaBeads_256_averaged.xtekct'
+reader = NikonDataReader()
+reader.set_up(xtek_file = xtek_file,
+              binning = [1, 1],
+              roi = -1,
+              normalize = True,
+              flip = True)
+
+data = reader.load_projections()
+print(data)
+ag = reader.get_geometry()
+print(ag)
+
+plt.imshow(data.as_array()[1, :, :])
+plt.show()
+'''

--- a/Wrappers/Python/ccpi/io/TXRMDataReader.py
+++ b/Wrappers/Python/ccpi/io/TXRMDataReader.py
@@ -53,134 +53,17 @@ class TXRMDataReader(object):
         if self.txrm_file == None:
             raise Exception('Path to txrm file is required.')
         
-        # check if xtek file exists
+        # check if txrm file exists
         if not(os.path.isfile(self.txrm_file)):
             raise Exception('File\n {}\n does not exist.'.format(self.txrm_file))  
-                
-        '''        
-        # parse xtek file
-        with open(self.xtek_file, 'r') as f:
-            content = f.readlines()    
-                
-        content = [x.strip() for x in content]
-        
-        for line in content:
-            # filename of TIFF files
-            if line.startswith("Name"):
-                self._experiment_name = line.split('=')[1]
-            # number of projections
-            elif line.startswith("Projections"):
-                num_projections = int(line.split('=')[1])
-            # white level - used for normalization
-            elif line.startswith("WhiteLevel"):
-                self._white_level = float(line.split('=')[1])
-            # number of pixels along Y axis
-            elif line.startswith("DetectorPixelsY"):
-                pixel_num_v_0 = int(line.split('=')[1])
-            # number of pixels along X axis
-            elif line.startswith("DetectorPixelsX"):
-                pixel_num_h_0 = int(line.split('=')[1])
-            # pixel size along X axis
-            elif line.startswith("DetectorPixelSizeX"):
-                pixel_size_h_0 = float(line.split('=')[1])
-            # pixel size along Y axis
-            elif line.startswith("DetectorPixelSizeY"):
-                pixel_size_v_0 = float(line.split('=')[1])
-            # source to center of rotation distance
-            elif line.startswith("SrcToObject"):
-                source_x = float(line.split('=')[1])
-            # source to detector distance
-            elif line.startswith("SrcToDetector"):
-                detector_x = float(line.split('=')[1])
-            # initial angular position of a rotation stage
-            elif line.startswith("InitialAngle"):
-                initial_angle = float(line.split('=')[1])
-            # angular increment (in degrees)
-            elif line.startswith("AngularStep"):
-                angular_step = float(line.split('=')[1])
-                
-        if self.roi == -1:
-            self._roi_par = [(0, pixel_num_v_0), \
-                              (0, pixel_num_h_0)]
-        else:
-            self._roi_par = self.roi.copy()
-            if self._roi_par[0] == -1:
-                self._roi_par[0] = (0, pixel_num_v_0)
-            if self._roi_par[1] == -1:
-                self._roi_par[1] = (0, pixel_num_h_0)
-                
-        # calculate number of pixels and pixel size
-        if (self.binning == [1, 1]):
-            pixel_num_v = self._roi_par[0][1] - self._roi_par[0][0]
-            pixel_num_h = self._roi_par[1][1] - self._roi_par[1][0]
-            pixel_size_v = pixel_size_v_0
-            pixel_size_h = pixel_size_h_0
-        else:
-            pixel_num_v = (self._roi_par[0][1] - self._roi_par[0][0]) // self.binning[0]
-            pixel_num_h = (self._roi_par[1][1] - self._roi_par[1][0]) // self.binning[1]
-            pixel_size_v = pixel_size_v_0 * self.binning[0]
-            pixel_size_h = pixel_size_h_0 * self.binning[1]
-        '''
-        
-        '''
-        Parse the angles file .ang or _ctdata.txt file and returns the angles
-        as an numpy array. 
-        '''
-        '''
-        input_path = os.path.dirname(self.xtek_file)
-        angles_ctdata_file = os.path.join(input_path, '_ctdata.txt')
-        angles_named_file = os.path.join(input_path, self._experiment_name+'.ang')
-        angles = numpy.zeros(num_projections, dtype = 'float')
-        
-        # look for _ctdata.txt
-        if os.path.exists(angles_ctdata_file):
-            # read txt file with angles
-            with open(angles_ctdata_file) as f:
-                content = f.readlines()
-            # skip firt three lines
-            # read the middle value of 3 values in each line as angles in degrees
-            index = 0
-            for line in content[3:]:
-                angles[index] = float(line.split(' ')[1])
-                index += 1
-            angles = angles + initial_angle
-        
-        # look for ang file
-        elif os.path.exists(angles_named_file):
-            # read the angles file which is text with first line as header
-            with open(angles_named_file) as f:
-                content = f.readlines()
-            # skip first line
-            index = 0
-            for line in content[1:]:
-                angles[index] = float(line.split(':')[1])
-                index += 1
-            angles = numpy.flipud(angles + initial_angle) # angles are in the reverse order
-            
-        else:   # calculate angles based on xtek file
-            angles = initial_angle + angular_step * range(num_projections)
-        
-        # fill in metadata
-        self._ag = AcquisitionGeometry(geom_type = 'cone', 
-                                       dimension = '3D', 
-                                       angles = angles, 
-                                       pixel_num_h = pixel_num_h, 
-                                       pixel_size_h = pixel_size_h, 
-                                       pixel_num_v = pixel_num_v, 
-                                       pixel_size_v = pixel_size_v, 
-                                       dist_source_center = source_x, 
-                                       dist_center_detector = detector_x - source_x, 
-                                       channels = 1,
-                                       angle_unit = 'degree')
-        '''
 
-    #def get_geometry(self):
-    #    
-    #    '''
-    #    Return AcquisitionGeometry object
-    #    '''
-    #    
-    #    return self._ag
+    def get_geometry(self):
+        
+        '''
+        Return AcquisitionGeometry object
+        '''
+        
+        return self._ag
         
     def load_projections(self):
         
@@ -227,11 +110,6 @@ class TXRMDataReader(object):
                                        dist_center_detector = DtoCdist, 
                                        channels = 1,
                                        angle_unit = 'degree')
-        
-        
-        #if (self.normalize):
-        #    data /= self._white_level
-        #    data[data > 1] = 1
 
         return AcquisitionData(array = data, 
                                deep_copy = False,
@@ -242,9 +120,7 @@ class TXRMDataReader(object):
                 
 if __name__ == '__main__':
     
-    from ccpi.framework import ImageGeometry, ImageData
-    from ccpi.astra.operators import AstraProjectorSimple
-    from ccpi.optimisation.algorithms import FISTA, CGLS, SIRT
+    from ccpi.framework import ImageGeometry
     from ccpi.astra.processors import FBP
     import matplotlib.pyplot as plt
     
@@ -285,7 +161,6 @@ if __name__ == '__main__':
     plt.imshow(data2d.as_array())
     plt.colorbar()
     plt.gray()
-    plt.savefig('walnut_sinotrans.png',dpi=300)
     
     data2d.log(out=data2d)
     data2d *= -1
@@ -294,7 +169,6 @@ if __name__ == '__main__':
     plt.imshow(data2d.as_array())
     plt.colorbar()
     plt.gray()
-    plt.savefig('walnut_sinoabs.png',dpi=300)
     
     # Choose the number of voxels to reconstruct onto as number of detector pixels
     N = data.geometry.pixel_num_h
@@ -325,21 +199,5 @@ if __name__ == '__main__':
     plt.imshow(recfbp.as_array())
     plt.gray()
     plt.colorbar()
-    plt.savefig('walnut_2DFBP.png',dpi=300)
-
-    '''
-    # Set up the Projector (AcquisitionModel) using ASTRA on GPU
-    Aop = AstraProjectorSimple(ig2d, ag2d,"cpu")
     
-    # Set initial guess for CGLS reconstruction
-    x_init = ImageData(geometry=ig2d)
     
-    # Set tolerance and number of iterations for reconstruction algorithms.
-    opt = {'tol': 1e-4, 'iter': 2}
-    
-    # First a CGLS reconstruction can be done:
-    CGLS_alg = SIRT()
-    CGLS_alg.set_up(x_init, Aop, data2d)
-    CGLS_alg.max_iteration = 2000
-    CGLS_alg.run(opt['iter'])
-    '''

--- a/Wrappers/Python/ccpi/io/__init__.py
+++ b/Wrappers/Python/ccpi/io/__init__.py
@@ -19,3 +19,4 @@
 from .NEXUSDataReader import NEXUSDataReader
 from .NEXUSDataWriter import NEXUSDataWriter
 from .NikonDataReader import NikonDataReader
+from .TXRMDataReader import TXRMDataReader

--- a/Wrappers/Python/test/test_io.py
+++ b/Wrappers/Python/test/test_io.py
@@ -53,31 +53,31 @@ class TestNexusReaderWriter(unittest.TestCase):
         print ("has_olefile",has_olefile)
         print ("has_dxchange",has_dxchange)
         print ("has_file",has_file)
-        
-        self.reader = TXRMDataReader()
-        angle_unit = AcquisitionGeometry.RADIAN
-
-        self.reader.set_up(txrm_file=filename, 
-                           angle_unit=angle_unit)
-        data = self.reader.load_projections()
-        # Choose the number of voxels to reconstruct onto as number of detector pixels
-        N = data.geometry.pixel_num_h
-        
-        # Geometric magnification
-        mag = (np.abs(data.geometry.dist_center_detector) + \
-               np.abs(data.geometry.dist_source_center)) / \
-               np.abs(data.geometry.dist_source_center)
+        if has_file:
+            self.reader = TXRMDataReader()
+            angle_unit = AcquisitionGeometry.RADIAN
             
-        # Voxel size is detector pixel size divided by mag
-        voxel_size_h = data.geometry.pixel_size_h / mag
-        voxel_size_v = data.geometry.pixel_size_v / mag
+            self.reader.set_up(txrm_file=filename, 
+                            angle_unit=angle_unit)
+            data = self.reader.load_projections()
+            # Choose the number of voxels to reconstruct onto as number of detector pixels
+            N = data.geometry.pixel_num_h
+            
+            # Geometric magnification
+            mag = (np.abs(data.geometry.dist_center_detector) + \
+                np.abs(data.geometry.dist_source_center)) / \
+                np.abs(data.geometry.dist_source_center)
+                
+            # Voxel size is detector pixel size divided by mag
+            voxel_size_h = data.geometry.pixel_size_h / mag
+            voxel_size_v = data.geometry.pixel_size_v / mag
 
-        self.mag = mag
-        self.N = N
-        self.voxel_size_h = voxel_size_h
-        self.voxel_size_v = voxel_size_v
+            self.mag = mag
+            self.N = N
+            self.voxel_size_h = voxel_size_h
+            self.voxel_size_v = voxel_size_v
 
-        self.data = data
+            self.data = data
 
 
     def tearDown(self):

--- a/Wrappers/Python/test/test_io.py
+++ b/Wrappers/Python/test/test_io.py
@@ -41,6 +41,10 @@ print ("has_wget",has_wget)
 print ("has_olefile",has_olefile)
 print ("has_dxchange",has_dxchange)
 print ("has_file",has_file)
+
+if not has_file:
+    print("This unittest requires the walnut Zeiss dataset saved in {}".format(data_dir))
+
 class TestNexusReaderWriter(unittest.TestCase):
     
     def setUp(self):
@@ -49,6 +53,7 @@ class TestNexusReaderWriter(unittest.TestCase):
         print ("has_olefile",has_olefile)
         print ("has_dxchange",has_dxchange)
         print ("has_file",has_file)
+        
         self.reader = TXRMDataReader()
         angle_unit = AcquisitionGeometry.RADIAN
 

--- a/Wrappers/Python/test/test_io.py
+++ b/Wrappers/Python/test/test_io.py
@@ -81,8 +81,16 @@ class TestNexusReaderWriter(unittest.TestCase):
 
 
     def tearDown(self):
-        fname = os.path.join(data_dir, 'walnut_slice512.nxs')
-        os.remove(fname)
+        pass
+
+    def test_run_test(self):
+        print("run test Zeiss Reader")
+        self.assertTrue(True)
+    
+    @unittest.skipIf(True, 'skip test by default')
+    def test_not_run_test(self):
+        print("run test Zeiss Reader")
+        self.assertTrue(True)
 
     @unittest.skipIf(not has_prerequisites, "Prerequisites not met")
     def test_load_and_reconstruct_2D(self):
@@ -115,4 +123,6 @@ class TestNexusReaderWriter(unittest.TestCase):
         print ("MSE" , qm )
 
         np.testing.assert_almost_equal(qm, 0)
+        fname = os.path.join(data_dir, 'walnut_slice512.nxs')
+        os.remove(fname)
 

--- a/Wrappers/Python/test/test_io.py
+++ b/Wrappers/Python/test/test_io.py
@@ -1,0 +1,113 @@
+import unittest
+from ccpi.framework import AcquisitionData, AcquisitionGeometry
+import numpy as np
+import os
+import olefile
+from ccpi.framework import ImageGeometry
+from ccpi.io import TXRMDataReader, NEXUSDataReader
+has_astra = True
+try:
+    from ccpi.astra.processors import FBP
+except ImportError as ie:
+    has_astra = False
+from ccpi.framework.TestData import data_dir
+filename = os.path.join(data_dir, "valnut_tomo-A.txrm")
+has_file = os.path.isfile(filename)
+
+has_dxchange = True
+try:
+    import dxchange
+except ImportError as ie:
+    has_dxchange = False
+has_olefile = True
+try:
+    import olefile
+except ImportError as ie:
+    has_olefile = False
+has_wget = True
+try:
+    import wget
+except ImportError as ie:
+    has_wget = False
+has_prerequisites = has_olefile and has_dxchange and has_astra and has_file \
+    and has_wget
+import wget
+
+
+from ccpi.utilities.quality_measures import mae, mse, psnr
+
+print ("has_astra",has_astra)
+print ("has_wget",has_wget)
+print ("has_olefile",has_olefile)
+print ("has_dxchange",has_dxchange)
+print ("has_file",has_file)
+class TestNexusReaderWriter(unittest.TestCase):
+    
+    def setUp(self):
+        print ("has_astra",has_astra)
+        print ("has_wget",has_wget)
+        print ("has_olefile",has_olefile)
+        print ("has_dxchange",has_dxchange)
+        print ("has_file",has_file)
+        self.reader = TXRMDataReader()
+        angle_unit = AcquisitionGeometry.RADIAN
+
+        self.reader.set_up(txrm_file=filename, 
+                           angle_unit=angle_unit)
+        data = self.reader.load_projections()
+        # Choose the number of voxels to reconstruct onto as number of detector pixels
+        N = data.geometry.pixel_num_h
+        
+        # Geometric magnification
+        mag = (np.abs(data.geometry.dist_center_detector) + \
+               np.abs(data.geometry.dist_source_center)) / \
+               np.abs(data.geometry.dist_source_center)
+            
+        # Voxel size is detector pixel size divided by mag
+        voxel_size_h = data.geometry.pixel_size_h / mag
+        voxel_size_v = data.geometry.pixel_size_v / mag
+
+        self.mag = mag
+        self.N = N
+        self.voxel_size_h = voxel_size_h
+        self.voxel_size_v = voxel_size_v
+
+        self.data = data
+
+
+    def tearDown(self):
+        fname = os.path.join(data_dir, 'walnut_slice512.nxs')
+        os.remove(fname)
+
+    @unittest.skipIf(not has_prerequisites, "Prerequisites not met")
+    def test_load_and_reconstruct_2D(self):
+        
+        # get central slice
+        data2d = self.data.subset(vertical=512)
+        # neg log
+        data2d.log(out=data2d)
+        data2d *= -1
+
+        
+        # Construct the appropriate ImageGeometry
+        ig2d = ImageGeometry(voxel_num_x=self.N,
+                            voxel_num_y=self.N,
+                            voxel_size_x=self.voxel_size_h, 
+                            voxel_size_y=self.voxel_size_h)
+        fbpalg = FBP(ig2d,data2d.geometry)
+        fbpalg.set_input(data2d)
+        
+        recfbp = fbpalg.get_output()
+        
+        wget.download('https://www.ccpi.ac.uk/sites/www.ccpi.ac.uk/files/walnut_slice512.nxs',
+                      out=data_dir)
+        fname = os.path.join(data_dir, 'walnut_slice512.nxs')
+        reader = NEXUSDataReader()
+        reader.set_up(nexus_file=fname)
+        gt = reader.load_data()
+
+        qm = mse(gt, recfbp)
+        print ("MSE" , qm )
+
+        np.testing.assert_almost_equal(qm, 0)
+

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -43,6 +43,8 @@ requirements:
     - pillow
     - libgcc-ng # [linux]
     - openmp # [osx]
+    - dxchange
+    - olefile >=0.46
   
 about:
   home: http://www.ccpi.ac.uk


### PR DESCRIPTION
Adds a reader for Zeiss lab data in txrm format. Contains a demonstration in __main__ for a walnut data set. Works with ASTRA FBP, but not yet with CIL CGLS and SIRT, as NaNs occur.

Dependency: dxchange.

Closes #75