### PR TITLE
Add lower and upper input in SIRT, add SIRT unit tests

### DIFF
--- a/Wrappers/Python/ccpi/optimisation/algorithms/SIRT.py
+++ b/Wrappers/Python/ccpi/optimisation/algorithms/SIRT.py
@@ -25,6 +25,9 @@ from __future__ import division
 from __future__ import print_function
 
 from ccpi.optimisation.algorithms import Algorithm
+from ccpi.optimisation.functions import IndicatorBox
+
+from numpy import inf
 
 class SIRT(Algorithm):
 
@@ -43,42 +46,59 @@ class SIRT(Algorithm):
                 e.g.  :math:`x\in[0, 1]`, :code:`IndicatorBox` to enforce box constraints
                         Default is :code:`None`).
     '''
-    def __init__(self, x_init=None, operator=None, data=None, constraint=None, **kwargs):
+    def __init__(self, x_init=None, operator=None, data=None, lower=None, upper=None, constraint=None, **kwargs):
         '''SIRT algorithm creator
 
        Optional parameters:
 
       :param x_init: Initial guess
       :param operator: Linear operator for the inverse problem
-      :param data: Acquired data to reconstruct       
-      :param constraint: Function proximal method
+      :param data: Acquired data to reconstruct 
+      :param lower: Scalar specifying lower bound constraint on pixel values, default -inf
+      :param upper: Scalar specifying upper bound constraint on pixel values, default +inf
+      :param constraint: More general constraint, given as Function proximal method
                    e.g.  :math:`x\in[0, 1]`, :code:`IndicatorBox` to enforce box constraints
-                         Default is :code:`None`).'''
+                         Default is :code:`None`). constraint takes priority over lower and upper.'''
         super(SIRT, self).__init__(**kwargs)
 
         if x_init is not None and operator is not None and data is not None:
-            self.set_up(x_init=x_init, operator=operator, data=data, constraint=constraint)
+            self.set_up(x_init=x_init, operator=operator, data=data, lower=lower, upper=upper, constraint=constraint)
 
-    def set_up(self, x_init, operator, data, constraint=None):
+    def set_up(self, x_init, operator, data, lower=None, upper=None, constraint=None):
         '''initialisation of the algorithm
 
         :param x_init: Initial guess
         :param operator: Linear operator for the inverse problem
-        :param data: Acquired data to reconstruct       
-        :param constraint: Function proximal method
+        :param data: Acquired data to reconstruct
+        :param lower: Scalar specifying lower bound constraint on pixel values, default -inf
+        :param upper: Scalar specifying upper bound constraint on pixel values, default +inf
+        :param constraint: More general constraint, given as Function proximal method
                    e.g.  :math:`x\in[0, 1]`, :code:`IndicatorBox` to enforce box constraints
-                         Default is :code:`None`).'''
+                         Default is :code:`None`). constraint takes priority over lower and upper.'''
         print("{} setting up".format(self.__class__.__name__, ))
         
         self.x = x_init.copy()
         self.operator = operator
         self.data = data
-        self.constraint = constraint
         
         self.r = data.copy()
         
         self.relax_par = 1.0
         
+        # Set constraints. If "constraint" is given, it should be an indicator
+        # function, and in that case "lower" and "upper" inputs are ignored. If
+        # "constraint" is not given, then "lower" and "upper" are looked at, 
+        # and if at least one is not None, then an IndicatorBox is set up which 
+        # provides the proximal mapping to enforce lower and upper bounds.
+        self.constraint = constraint
+        if constraint is None:
+            if lower is not None or upper is not None:
+                if lower is None:
+                    lower=-inf
+                if upper is None:
+                    upper=inf
+                self.constraint=IndicatorBox(lower=lower,upper=upper)
+                
         # Set up scaling matrices D and M.
         self.M = 1/self.operator.direct(self.operator.domain_geometry().allocate(value=1.0))        
         self.D = 1/self.operator.adjoint(self.operator.range_geometry().allocate(value=1.0))

--- a/Wrappers/Python/test/test_algorithms.py
+++ b/Wrappers/Python/test/test_algorithms.py
@@ -184,7 +184,9 @@ class TestAlgorithms(unittest.TestCase):
         alg2 = SIRT(x_init=x_init, operator=identity, data=b, upper=0.3)
         alg2.max_iteration = 200
         alg2.run(20, verbose=True)
-        self.assertTrue(alg2.get_output().max()==0.3)
+        self.assertLessEqual(alg2.get_output().max(), 0.3)
+	# maybe we could add a test to compare alg.get_output() when < upper bound is 
+	# the same as alg2.get_output() and otherwise 0.3
         
     def test_FISTA(self):
         print ("Test FISTA")

--- a/Wrappers/Python/test/test_algorithms.py
+++ b/Wrappers/Python/test/test_algorithms.py
@@ -184,7 +184,23 @@ class TestAlgorithms(unittest.TestCase):
         alg2 = SIRT(x_init=x_init, operator=identity, data=b, upper=0.3)
         alg2.max_iteration = 200
         alg2.run(20, verbose=True)
-        self.assertLessEqual(alg2.get_output().max(), 0.3)
+        # equal 
+        try:
+            numpy.testing.assert_equal(alg2.get_output().max(), 0.3)
+            print ("Equal OK, returning")
+            return
+        except AssertionError as ae:
+            print ("Not equal, trying almost equal")
+        # almost equal to 7 digits or less
+        try:
+            numpy.testing.assert_almost_equal(alg2.get_output().max(), 0.3)
+            print ("Almost Equal OK, returning")
+            return
+        except AssertionError as ae:
+            print ("Not almost equal, trying less")
+        numpy.testing.assert_array_less(alg2.get_output().max(), 0.3)
+
+        # self.assertLessEqual(alg2.get_output().max(), 0.3)
 	# maybe we could add a test to compare alg.get_output() when < upper bound is 
 	# the same as alg2.get_output() and otherwise 0.3
         

--- a/Wrappers/Python/test/test_algorithms.py
+++ b/Wrappers/Python/test/test_algorithms.py
@@ -29,6 +29,7 @@ from ccpi.optimisation.functions import LeastSquares, ZeroFunction, \
    L2NormSquared, FunctionOperatorComposition
 from ccpi.optimisation.algorithms import GradientDescent
 from ccpi.optimisation.algorithms import CGLS
+from ccpi.optimisation.algorithms import SIRT
 from ccpi.optimisation.algorithms import FISTA
 
 from ccpi.optimisation.algorithms import PDHG
@@ -159,6 +160,31 @@ class TestAlgorithms(unittest.TestCase):
         self.assertTrue(alg.update_objective_interval==2)
         alg.run(20, verbose=True)
         self.assertNumpyArrayAlmostEqual(alg.x.as_array(), b.as_array())
+    
+    def test_SIRT(self):
+        print ("Test CGLS")
+        #ig = ImageGeometry(124,153,154)
+        ig = ImageGeometry(10,2)
+        numpy.random.seed(2)
+        x_init = ig.allocate(0.)
+        b = ig.allocate('random')
+        # b = x_init.copy()
+        # fill with random numbers
+        # b.fill(numpy.random.random(x_init.shape))
+        # b = ig.allocate()
+        # bdata = numpy.reshape(numpy.asarray([i for i in range(20)]), (2,10))
+        # b.fill(bdata)
+        identity = Identity(ig)
+        
+        alg = SIRT(x_init=x_init, operator=identity, data=b)
+        alg.max_iteration = 200
+        alg.run(20, verbose=True)
+        self.assertNumpyArrayAlmostEqual(alg.x.as_array(), b.as_array())
+        
+        alg2 = SIRT(x_init=x_init, operator=identity, data=b, upper=0.3)
+        alg2.max_iteration = 200
+        alg2.run(20, verbose=True)
+        self.assertTrue(alg2.get_output().max()==0.3)
         
     def test_FISTA(self):
         print ("Test FISTA")


### PR DESCRIPTION
upper and lower arguments added. argument constraint is kept and takes priority over new lower and upper arguments, if provided. This preserves backwards compatibility.

Also there were no unit tests for SIRT, so added one for unconstrained case and one with upper bound.

Closes #603.