### PR TITLE
renamed FunctionOperatorComposition and SumFunctionScalar

### DIFF
--- a/Wrappers/Python/cil/optimisation/functions/Function.py
+++ b/Wrappers/Python/cil/optimisation/functions/Function.py
@@ -113,8 +113,8 @@ class Function(object):
         
         if isinstance(other, Function):
             return SumFunction(self, other)
-        elif isinstance(other, (SumFunctionScalar, ConstantFunction, Number)):
-            return SumFunctionScalar(self, other)
+        elif isinstance(other, (SumScalarFunction, ConstantFunction, Number)):
+            return SumScalarFunction(self, other)
         else:
             raise ValueError('Not implemented')   
             
@@ -306,9 +306,9 @@ class ScaledFunction(Function):
             self.function.proximal_conjugate(x/self.scalar, tau/self.scalar, out=out)
             out *= self.scalar
 
-class SumFunctionScalar(SumFunction):
+class SumScalarFunction(SumFunction):
           
-    """ SumFunctionScalar represents the sum a function with a scalar. 
+    """ SumScalarFunction represents the sum a function with a scalar. 
     
         .. math:: (F + scalar)(x)  = F(x) + scalar
     
@@ -324,7 +324,7 @@ class SumFunctionScalar(SumFunction):
     
     def __init__(self, function, constant):
         
-        super(SumFunctionScalar, self).__init__(function, ConstantFunction(constant))        
+        super(SumScalarFunction, self).__init__(function, ConstantFunction(constant))        
         self.constant = constant
         self.function = function
         
@@ -357,7 +357,7 @@ class SumFunctionScalar(SumFunction):
     @L.setter
     def L(self, value):
         # call base class setter
-        super(SumFunctionScalar, self.__class__).L.fset(self, value )
+        super(SumScalarFunction, self.__class__).L.fset(self, value )
 
 class ConstantFunction(Function):
     

--- a/Wrappers/Python/cil/optimisation/functions/OperatorCompositionFunction.py
+++ b/Wrappers/Python/cil/optimisation/functions/OperatorCompositionFunction.py
@@ -28,7 +28,7 @@ from cil.optimisation.operators import Operator, ScaledOperator
 
 import warnings
 
-class FunctionOperatorComposition(Function):
+class OperatorCompositionFunction(Function):
     
     """ Composition of a function with an operator as : :math:`(F \otimes A)(x) = F(Ax)`
     
@@ -50,7 +50,7 @@ class FunctionOperatorComposition(Function):
     :type f: :code:`Function`
     '''
 
-        super(FunctionOperatorComposition, self).__init__()
+        super(OperatorCompositionFunction, self).__init__()
         
         if not isinstance(function, Function):
             raise ValueError('{} is not function '.format(type(self.function)))

--- a/Wrappers/Python/cil/optimisation/functions/__init__.py
+++ b/Wrappers/Python/cil/optimisation/functions/__init__.py
@@ -18,14 +18,14 @@
 
 from __future__ import absolute_import
 
-from .Function import Function, ConstantFunction, ZeroFunction, TranslateFunction, SumFunctionScalar
+from .Function import Function, ConstantFunction, ZeroFunction, TranslateFunction, SumScalarFunction
 from .Function import ScaledFunction
 from .L1Norm import L1Norm
 from .L2NormSquared import L2NormSquared
 from .L2NormSquared import WeightedL2NormSquared
 from .LeastSquares import LeastSquares
 from .BlockFunction import BlockFunction
-from .FunctionOperatorComposition import FunctionOperatorComposition
+from .OperatorCompositionFunction import OperatorCompositionFunction
 from .MixedL21Norm import MixedL21Norm, SmoothMixedL21Norm
 from .IndicatorBox import IndicatorBox
 from .KullbackLeibler import KullbackLeibler

--- a/Wrappers/Python/test/test_TranslateFunction.py
+++ b/Wrappers/Python/test/test_TranslateFunction.py
@@ -21,7 +21,7 @@ from cil.optimisation.functions import Function, L1Norm, ScaledFunction, \
                                         LeastSquares, L2NormSquared, \
                                         KullbackLeibler, ZeroFunction, \
                                         ConstantFunction, TranslateFunction, \
-                                        MixedL21Norm, FunctionOperatorComposition
+                                        MixedL21Norm
 from cil.optimisation.operators import GradientOperator
 from cil.framework import ImageGeometry, BlockGeometry
 

--- a/Wrappers/Python/test/test_algorithms.py
+++ b/Wrappers/Python/test/test_algorithms.py
@@ -31,7 +31,7 @@ from cil.optimisation.operators import IdentityOperator
 from cil.optimisation.operators import GradientOperator, BlockOperator, FiniteDifferenceOperator
 
 from cil.optimisation.functions import LeastSquares, ZeroFunction, \
-   L2NormSquared, FunctionOperatorComposition
+   L2NormSquared, OperatorCompositionFunction
 from cil.optimisation.functions import MixedL21Norm, BlockFunction, L1Norm, KullbackLeibler                     
 from cil.optimisation.functions import IndicatorBox
 
@@ -197,7 +197,7 @@ class TestAlgorithms(unittest.TestCase):
 	#### it seems FISTA does not work with Nowm2Sq
         # norm2sq = Norm2Sq(identity, b)
         # norm2sq.L = 2 * norm2sq.c * identity.norm()**2
-        norm2sq = FunctionOperatorComposition(L2NormSquared(b=b), identity)
+        norm2sq = OperatorCompositionFunction(L2NormSquared(b=b), identity)
         opt = {'tol': 1e-4, 'memopt':False}
         print ("initial objective", norm2sq(x_init))
         alg = FISTA(x_init=x_init, f=norm2sq, g=ZeroFunction())
@@ -225,7 +225,7 @@ class TestAlgorithms(unittest.TestCase):
 	    #### it seems FISTA does not work with Nowm2Sq
         norm2sq = LeastSquares(identity, b)
         #norm2sq.L = 2 * norm2sq.c * identity.norm()**2
-        #norm2sq = FunctionOperatorComposition(L2NormSquared(b=b), identity)
+        #norm2sq = OperatorCompositionFunction(L2NormSquared(b=b), identity)
         opt = {'tol': 1e-4, 'memopt':False}
         print ("initial objective", norm2sq(x_init))
         alg = FISTA(x_init=x_init, f=norm2sq, g=ZeroFunction())
@@ -256,7 +256,7 @@ class TestAlgorithms(unittest.TestCase):
         print ('Lipschitz', norm2sq.L)
         # norm2sq.L = None
         #norm2sq.L = 2 * norm2sq.c * identity.norm()**2
-        #norm2sq = FunctionOperatorComposition(L2NormSquared(b=b), identity)
+        #norm2sq = OperatorCompositionFunction(L2NormSquared(b=b), identity)
         opt = {'tol': 1e-4, 'memopt':False}
         print ("initial objective", norm2sq(x_init))
         try:
@@ -399,7 +399,7 @@ class TestAlgorithms(unittest.TestCase):
         # Setup and run the FISTA algorithm
         operator = GradientOperator(ig)
         fid = KullbackLeibler(b=noisy_data)
-        reg = FunctionOperatorComposition(alpha * L2NormSquared(), operator)
+        reg = OperatorCompositionFunction(alpha * L2NormSquared(), operator)
 
         x_init = ig.allocate()
         fista = FISTA(x_init=x_init , f=reg, g=fid)

--- a/Wrappers/Python/test/test_functions.py
+++ b/Wrappers/Python/test/test_functions.py
@@ -27,7 +27,7 @@ from cil.optimisation.operators import GradientOperator
 
 from cil.optimisation.functions import Function, KullbackLeibler, WeightedL2NormSquared, L2NormSquared,\
                                          L1Norm, MixedL21Norm, LeastSquares, \
-                                         ZeroFunction, FunctionOperatorComposition,\
+                                         ZeroFunction, OperatorCompositionFunction,\
                                          Rosenbrock, IndicatorBox, TotalVariation                                     
 
 import unittest
@@ -345,9 +345,9 @@ class TestFunction(unittest.TestCase):
         # numpy.testing.assert_array_almost_equal(f_scaled_data.proximal_conjugate(u, tau).as_array(), \
         #                                         ((u - tau * b)/(1 + tau/(2*scalar) )).as_array(), decimal=4)    
            
-    def test_Norm2sq_as_FunctionOperatorComposition(self):
+    def test_Norm2sq_as_OperatorCompositionFunction(self):
         
-        print('Test for FunctionOperatorComposition')         
+        print('Test for OperatorCompositionFunction')         
             
         M, N = 50, 50
         ig = ImageGeometry(voxel_num_x=M, voxel_num_y = N)
@@ -359,7 +359,7 @@ class TestFunction(unittest.TestCase):
             
         u = ig.allocate('random', seed = 50)
         f = 0.5 * L2NormSquared(b = b)
-        func1 = FunctionOperatorComposition(f, operator)
+        func1 = OperatorCompositionFunction(f, operator)
         func2 = LeastSquares(operator, b, 0.5)
         print("f.L {}".format(f.L))
         print("0.5*f.L {}".format((0.5*f).L))
@@ -391,7 +391,7 @@ class TestFunction(unittest.TestCase):
         b = vg.allocate('random')    
         u = vg.allocate('random')
           
-        func1 = FunctionOperatorComposition(0.5 * L2NormSquared(b = b), operator)
+        func1 = OperatorCompositionFunction(0.5 * L2NormSquared(b = b), operator)
         func2 = LeastSquares(operator, b, 0.5)
          
         self.assertNumpyArrayAlmostEqual(func1(u), func2(u))       
@@ -827,7 +827,7 @@ class TestFunction(unittest.TestCase):
         numpy.testing.assert_almost_equal(res1, res2, decimal=2)          
 
     def test_Lipschitz(self):
-        print('Test for FunctionOperatorComposition')         
+        print('Test for OperatorCompositionFunction')         
             
         M, N = 50, 50
         ig = ImageGeometry(voxel_num_x=M, voxel_num_y = N)


### PR DESCRIPTION
closes #702
Notice that concrete functions like LeastSquares or KullbackLeibler do not have postfix Function.