### PR TITLE
fixes when find_library returs None

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ where,
 
 ## Building from source code 
 
+### Getting the code
+
 In case of development it is useful to be able to build the software directly. You should clone this repository as
 ```bash
 
@@ -43,6 +45,19 @@ The use of `--recurse-submodule` is necessary if the user wants the examples dat
 
 git submodule update --init
 ```
+
+### Build with CMake
+CMake and a C++ compiler are required to build the source code. Let's suppose that the user is in the source directory, then the following commands should work:
+
+```bash
+
+mkdir build
+cd build
+cmake .. -DCMAKE_INSTALL_PREFIX=<install_directory>
+cmake --build . --target install
+```
+
+The user then needs to add the path to `<install_directory>/lib` where the library is installed to the environment variable `PATH` or `LD_LIBRARY_PATH`, depending on system
 
 ### Components
 

--- a/Wrappers/Python/cil/framework/framework.py
+++ b/Wrappers/Python/cil/framework/framework.py
@@ -32,17 +32,14 @@ from cil.utilities.multiprocessing import NUM_THREADS
 if platform.system() == 'Linux':
     dll = 'libcilacc.so'
 elif platform.system() == 'Windows':
-    dll = 'cilacc.dll'
+    dll_file = 'cilacc.dll'
+    dll = util.find_library(dll_file)
 elif platform.system() == 'Darwin':
     dll = 'libcilacc.dylib'
 else:
     raise ValueError('Not supported platform, ', platform.system())
 
-dll_path = util.find_library(dll)
-if dll_path is None:
-    cilacc = ctypes.cdll.LoadLibrary(dll)
-else:
-    cilacc = ctypes.cdll.LoadLibrary(dll_path)
+cilacc = ctypes.cdll.LoadLibrary(dll)
 
 #default nThreads
 # import multiprocessing

--- a/Wrappers/Python/cil/framework/framework.py
+++ b/Wrappers/Python/cil/framework/framework.py
@@ -39,7 +39,10 @@ else:
     raise ValueError('Not supported platform, ', platform.system())
 
 dll_path = util.find_library(dll)
-cilacc = ctypes.cdll.LoadLibrary(dll_path)
+if dll_path is None:
+    cilacc = ctypes.cdll.LoadLibrary(dll)
+else:
+    cilacc = ctypes.cdll.LoadLibrary(dll_path)
 
 #default nThreads
 # import multiprocessing

--- a/Wrappers/Python/cil/optimisation/operators/GradientOperator.py
+++ b/Wrappers/Python/cil/optimisation/operators/GradientOperator.py
@@ -244,8 +244,10 @@ else:
     raise ValueError('Not supported platform, ', platform.system())
 
 dll_path = util.find_library(dll)
-cilacc = ctypes.cdll.LoadLibrary(dll_path)
-
+if dll_path is None:
+    cilacc = ctypes.cdll.LoadLibrary(dll)
+else:
+    cilacc = ctypes.cdll.LoadLibrary(dll_path)
 c_float_p = ctypes.POINTER(ctypes.c_float)
 
 cilacc.openMPtest.restypes = ctypes.c_int32

--- a/Wrappers/Python/cil/optimisation/operators/GradientOperator.py
+++ b/Wrappers/Python/cil/optimisation/operators/GradientOperator.py
@@ -237,17 +237,15 @@ from ctypes import util
 if platform.system() == 'Linux':
     dll = 'libcilacc.so'
 elif platform.system() == 'Windows':
-    dll = 'cilacc.dll'
+    dll_file = 'cilacc.dll'
+    dll = util.find_library(dll_file)
 elif platform.system() == 'Darwin':
     dll = 'libcilacc.dylib'
 else:
     raise ValueError('Not supported platform, ', platform.system())
 
-dll_path = util.find_library(dll)
-if dll_path is None:
-    cilacc = ctypes.cdll.LoadLibrary(dll)
-else:
-    cilacc = ctypes.cdll.LoadLibrary(dll_path)
+cilacc = ctypes.cdll.LoadLibrary(dll)
+
 c_float_p = ctypes.POINTER(ctypes.c_float)
 
 cilacc.openMPtest.restypes = ctypes.c_int32


### PR DESCRIPTION
This bug makes it impossible to load the cilacc library on a non conda build, e.g. SIRF SuperBuild.

Apparently, [`find_library`](https://docs.python.org/3/library/ctypes.html?highlight=find_library#ctypes.util.find_library) returns None and then everything else it fails.
