### PR TITLE
Numpy gradient

### DIFF
--- a/Wrappers/Python/cil/framework/framework.py
+++ b/Wrappers/Python/cil/framework/framework.py
@@ -234,8 +234,8 @@ class ImageGeometry(object):
 
     def get_order_by_label(self, dimension_labels, default_dimension_labels):
         order = []
-        for i, el in enumerate(dimension_labels):
-            for j, ek in enumerate(default_dimension_labels):
+        for i, el in enumerate(default_dimension_labels):
+            for j, ek in enumerate(dimension_labels):
                 if el == ek:
                     order.append(j)
                     break
@@ -1660,8 +1660,8 @@ class AcquisitionGeometry(object):
 
     def get_order_by_label(self, dimension_labels, default_dimension_labels):
         order = []
-        for i, el in enumerate(dimension_labels):
-            for j, ek in enumerate(default_dimension_labels):
+        for i, el in enumerate(default_dimension_labels):
+            for j, ek in enumerate(dimension_labels):
                 if el == ek:
                     order.append(j)
                     break

--- a/Wrappers/Python/test/test_Gradient.py
+++ b/Wrappers/Python/test/test_Gradient.py
@@ -163,6 +163,27 @@ class TestGradientOperator(unittest.TestCase):
         #print("GradientOperator, 4D, bnd_cond='Periodic', adjoint")
         numpy.testing.assert_array_equal(out_adjoint.as_array(), gold_adjoint.as_array())
 
+
+        #reordered
+        data.reorder(['vertical','horizontal_x','channel','horizontal_y'])
+        grad_py = GradientOperator(data.geometry, bnd_cond='Neumann', correlation='SpaceChannels', backend='numpy')
+        gold_direct = grad_py.direct(data)
+        gold_adjoint = grad_py.adjoint(gold_direct)
+
+        grad_c = GradientOperator(data.geometry, bnd_cond='Neumann', correlation='SpaceChannels', backend='c')
+        out_direct = grad_c.direct(data)
+        out_adjoint = grad_c.adjoint(out_direct)
+
+        #print("GradientOperator, 4D, bnd_cond='Neumann', direct")
+        numpy.testing.assert_array_equal(out_direct.get_item(0).as_array(), gold_direct.get_item(0).as_array())
+        numpy.testing.assert_array_equal(out_direct.get_item(1).as_array(), gold_direct.get_item(1).as_array())
+        numpy.testing.assert_array_equal(out_direct.get_item(2).as_array(), gold_direct.get_item(2).as_array())
+        numpy.testing.assert_array_equal(out_direct.get_item(3).as_array(), gold_direct.get_item(3).as_array())
+
+        #print("GradientOperator, 4D, bnd_cond='Neumann', adjoint")
+        numpy.testing.assert_array_equal(out_adjoint.as_array(), gold_adjoint.as_array())
+
+
     def test_GradientOperator_4D_allocate(self):
 
         nc, nz, ny, nx = 3, 4, 5, 6


### PR DESCRIPTION
This fixes a bug where gradient with backend `numpy` selected the wrong axis index. This would have not been an issue for data in the default cil order already, or for data in the exact reverse default cil order.

This also fixes an inconsistency between the return order of the direct call using the two backends. Previously `numpy` returned a `blockdatacontainer` with items in default cil ordering, `c` returned a `blockdatacontainer` with items  in the ordering of the input `dimension_labels`