### PR TITLE
show_geometry() implemented

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 * 21.x.x
   - add CCPi-Regularisation toolkit in unittests
+  - show_geometry implemented to display AcquisitionGeometry objects, can be imported from utilities.display
 
 * 21.1.0
   - Added TomoPhantom plugin to create 2D/3D + channel ImageData phantoms based on the TomoPhantom model library

--- a/Wrappers/Python/cil/framework/framework.py
+++ b/Wrappers/Python/cil/framework/framework.py
@@ -1239,10 +1239,10 @@ class Configuration(object):
     def configured(self):
         if self.system is None:
             print("Please configure AcquisitionGeometry using one of the following methods:\
-                    \n\tAcquisitionGeometry.Create_Parallel2D()\
-                    \n\tAcquisitionGeometry.Create_Cone3D()\
-                    \n\tAcquisitionGeometry.Create_Parallel2D()\
-                    \n\tAcquisitionGeometry.Create_Cone3D()")
+                    \n\tAcquisitionGeometry.create_Parallel2D()\
+                    \n\tAcquisitionGeometry.create_Cone3D()\
+                    \n\tAcquisitionGeometry.create_Parallel2D()\
+                    \n\tAcquisitionGeometry.create_Cone3D()")
             return False
 
         configured = True
@@ -1281,10 +1281,10 @@ class AcquisitionGeometry(object):
     r'''This class holds the AcquisitionGeometry of the system.
     
     Please initialise using factory:
-    AcquisitionGeometry.Create_Parallel2D
-    AcquisitionGeometry.Create_Cone3D
-    AcquisitionGeometry.Create_Parallel2D
-    AcquisitionGeometry.Create_Cone3D
+    AcquisitionGeometry.create_Parallel2D
+    AcquisitionGeometry.create_Cone3D
+    AcquisitionGeometry.create_Parallel2D
+    AcquisitionGeometry.create_Cone3D
 
 
     These initialisation parameters will be deprecated in a future release.    

--- a/Wrappers/Python/cil/utilities/display.py
+++ b/Wrappers/Python/cil/utilities/display.py
@@ -17,7 +17,7 @@
 
 
 #%%
-from cil.framework import ImageGeometry, AcquisitionData, ImageData, DataContainer, BlockDataContainer
+from cil.framework import AcquisitionGeometry, ImageGeometry, AcquisitionData, ImageData, DataContainer, BlockDataContainer
 import numpy as np
 from itertools import product, combinations
 
@@ -29,7 +29,7 @@ from mpl_toolkits.mplot3d import proj3d
 from matplotlib import gridspec
 from mpl_toolkits.axes_grid1 import make_axes_locatable
 
-class __PlotData(object):
+class _PlotData(object):
     def __init__(self, data, title, axis_labels, origin):
         self.data = data
         self.title = title
@@ -235,7 +235,7 @@ def show2D(datacontainers, title=None, slice_list=None, fix_range=False, axis_la
         else:
             plot_origin = origin
 
-        subplots.append(__PlotData(plot_data,plot_title,plot_axis_labels, plot_origin))
+        subplots.append(_PlotData(plot_data,plot_title,plot_axis_labels, plot_origin))
 
     #set range per subplot
     for i, subplot in enumerate(subplots):
@@ -335,7 +335,7 @@ def plotter2D(datacontainers, title=None, slice_list=None, fix_range=False, axis
 
 
 
-class __Arrow3D(FancyArrowPatch):
+class _Arrow3D(FancyArrowPatch):
 
     def __init__(self, xs, ys, zs, *args, **kwargs):
         FancyArrowPatch.__init__(self, (0, 0), (0, 0), *args, **kwargs)
@@ -347,7 +347,7 @@ class __Arrow3D(FancyArrowPatch):
         self.set_positions((xs[0], ys[0]), (xs[1], ys[1]))
         FancyArrowPatch.draw(self, renderer)
 
-class __ShowGeometry(object):
+class _ShowGeometry(object):
 
     def __init__(self, ag, ig=None):
 
@@ -399,7 +399,7 @@ class __ShowGeometry(object):
         self.display_detector()
         self.display_object()
 
-        if ag.geom_type == 'cone':
+        if self.ag.geom_type == 'cone':
             self.display_source()
         else:
             self.display_ray()
@@ -440,7 +440,7 @@ class __ShowGeometry(object):
             axis = np.zeros(3)
             axis[i] = 1 * self.scale
 
-            a = __Arrow3D(*zip(Oo,axis*2), mutation_scale=20,lw=1, arrowstyle="->", color="k")
+            a = _Arrow3D(*zip(Oo,axis*2), mutation_scale=20,lw=1, arrowstyle="->", color="k")
             self.ax.add_artist(a)
         
             self.ax.text(*(axis*2.2),labels[i], **self.text_options)
@@ -490,13 +490,13 @@ class __ShowGeometry(object):
 
         det_rows_dir = self.ag.config.system.detector.direction_x
 
-        x = __Arrow3D(*zip(do, self.scale * det_rows_dir + do), mutation_scale=20,lw=1, arrowstyle="-|>", color="b")
+        x = _Arrow3D(*zip(do, self.scale * det_rows_dir + do), mutation_scale=20,lw=1, arrowstyle="-|>", color="b")
         self.ax.add_artist(x)
         self.ax.text(*(1.2 * self.scale * det_rows_dir + do),r'$D_x$', **self.text_options)
 
         if self.ndim == 3:
             det_col_dir = self.ag.config.system.detector.direction_y
-            y = __Arrow3D(*zip(do, self.scale * det_col_dir + do), mutation_scale=20,lw=1, arrowstyle="-|>", color="b")
+            y = _Arrow3D(*zip(do, self.scale * det_col_dir + do), mutation_scale=20,lw=1, arrowstyle="-|>", color="b")
             self.ax.add_artist(y)
             self.ax.text(*(1.2 * self.scale * det_col_dir + do),r'$D_y$', **self.text_options)
 
@@ -521,7 +521,7 @@ class __ShowGeometry(object):
         if self.ndim == 3:
             # rotate axis arrow
             r1 = ro +  self.ag.config.system.rotation_axis.direction * self.scale * 2
-            arrow3 = __Arrow3D(*zip(ro,r1), mutation_scale=20,lw=1, arrowstyle="-|>", color="r")
+            arrow3 = _Arrow3D(*zip(ro,r1), mutation_scale=20,lw=1, arrowstyle="-|>", color="r")
             self.ax.add_artist(arrow3)
 
         #reconstruction volume
@@ -581,7 +581,7 @@ class __ShowGeometry(object):
             z[i] = float(point_rot[2] + ro[2])
 
         self.ax.plot3D(x,y,z, color='r',ls="dashed",alpha=1)
-        arrow4 = __Arrow3D(x[-2:],y[-2:],z[-2:],mutation_scale=20,lw=1, arrowstyle="-|>", color="r")
+        arrow4 = _Arrow3D(x[-2:],y[-2:],z[-2:],mutation_scale=20,lw=1, arrowstyle="-|>", color="r")
         self.ax.add_artist(arrow4)
 
         handles = [ 
@@ -626,7 +626,7 @@ class __ShowGeometry(object):
         
         for i in range(len(rays)):
             h0 = self.ax.plot3D(*zip(rays[i],det[i]), color='#D4BD72',ls="dashed",alpha=0.4, label='ray direction')[0]
-            arrow = __Arrow3D(*zip(rays[i],rays[i]+self.ag.config.system.ray.direction*self.scale ),mutation_scale=20,lw=1, arrowstyle="-|>", color="#D4BD72")
+            arrow = _Arrow3D(*zip(rays[i],rays[i]+self.ag.config.system.ray.direction*self.scale ),mutation_scale=20,lw=1, arrowstyle="-|>", color="#D4BD72")
             self.ax.add_artist(arrow)
 
         self.handles.append(h0)
@@ -651,9 +651,9 @@ def show_geometry(acquisition_geom, image_geom=None, elevation=20, azimuthal=-35
     :grid: Show figire axis
     :type grid: boolean, default=False     
     '''
-    if ag.dimension == '2D':
+    if acquisition_geom.dimension == '2D':
         elevation = 90
         azimuthal = 0
 
-    display = __ShowGeometry(acquisition_geom, image_geom)
+    display = _ShowGeometry(acquisition_geom, image_geom)
     display.draw(elev=elevation, azim=azimuthal, view_distance=view_distance, grid=grid)

--- a/Wrappers/Python/cil/utilities/display.py
+++ b/Wrappers/Python/cil/utilities/display.py
@@ -384,18 +384,20 @@ class _ShowGeometry(object):
         len2 = self.acquisition_geometry.config.panel.num_pixels[1] * self.acquisition_geometry.config.panel.pixel_size[1]
         self.scale = max(len1,len2)/5
 
-        self.text_options = {   'horizontalalignment': 'center',
-                                'verticalalignment': 'center',
-                                'fontsize': 15 }
 
         self.handles = []
         self.labels = []
 
-    def draw(self, elev=35, azim=35, view_distance=10, grid=False):
+    def draw(self, elev=35, azim=35, view_distance=10, grid=False, figsize=(15,15), fontsize=10):
 
-        self.fig = plt.figure(figsize=(15,15))
+        self.fig = plt.figure(figsize=figsize)
         self.ax = self.fig.add_subplot(111, projection='3d')
-        
+
+        self.text_options = {   'horizontalalignment': 'center',
+                                'verticalalignment': 'center',
+                                'fontsize': fontsize }
+
+
         self.display_world()
         self.display_detector()
         self.display_object()

--- a/Wrappers/Python/cil/utilities/display.py
+++ b/Wrappers/Python/cil/utilities/display.py
@@ -608,7 +608,7 @@ class _ShowGeometry(object):
         handles = [ 
             mlines.Line2D([], [], color='r',linestyle='solid', markersize=12, label='rotation axis direction'),
             mlines.Line2D([], [], color='r',linestyle='dashed', markersize=12, label=r'rotation direction $\theta$'),
-            mlines.Line2D([], [], color='r',linestyle='dotted', markersize=15, label='Imacquisition_geometrye geometry'),
+            mlines.Line2D([], [], color='r',linestyle='dotted', markersize=15, label='image geometry'),
             self.ax.scatter3D(*vox0, marker='x', alpha=1,color='r',lw=1,s=50, label='data origin (voxel 0)')
         ]
 

--- a/Wrappers/Python/cil/utilities/display.py
+++ b/Wrappers/Python/cil/utilities/display.py
@@ -519,7 +519,7 @@ class _ShowGeometry(object):
         handles=[
             self.ax.scatter3D(*do, marker='o', alpha=1,color='b',lw=1, label='detector position'),
             mlines.Line2D([], [], color='b',linestyle='solid', markersize=12, label='detector direction'),      
-            self.ax.plot3D(*zip(*det, det[0]), color='b',ls='dashed',alpha=1, label='detector')[0],
+            self.ax.plot3D(*zip(*det, det[0]), color='b',ls='dotted',alpha=1, label='detector')[0],
             self.ax.scatter3D(*pix0, marker='x', alpha=1,color='b',lw=1,s=50, label='data origin (pixel 0)'),            
         ]
 
@@ -584,7 +584,7 @@ class _ShowGeometry(object):
                 y_data = float(s[1]) + ro[1], float(e[1]) + ro[1]
                 z_data = float(s[2]) + ro[2], float(e[2]) + ro[2]
 
-                self.ax.plot3D(x_data,y_data,z_data, color="r",ls='dashed',alpha=0.8)
+                self.ax.plot3D(x_data,y_data,z_data, color="r",ls='dotted',alpha=1)
 
                 if count == 0:
                     vox0=(x_data[0],y_data[0],z_data[0])
@@ -594,7 +594,7 @@ class _ShowGeometry(object):
             x = [self.image_geometry.get_min_x(), self.image_geometry.get_max_x()]
             y = [self.image_geometry.get_min_y(), self.image_geometry.get_max_y()]
             vertex = np.array([(x[0],y[0],0),(x[0],y[1],0),(x[1],y[1],0),(x[1],y[0],0)]) + ro
-            self.ax.plot3D(*zip(*vertex, vertex[0]), color='r',ls='dashed',alpha=1)
+            self.ax.plot3D(*zip(*vertex, vertex[0]), color='r',ls='dotted',alpha=1)
             vox0=vertex[0]
             rotation_matrix = np.eye(3)
 
@@ -613,15 +613,15 @@ class _ShowGeometry(object):
             y[i] = float(point_rot[1] + ro[1])
             z[i] = float(point_rot[2] + ro[2])
 
-        self.ax.plot3D(x,y,z, color='r',ls="dotted",alpha=1)
+        self.ax.plot3D(x,y,z, color='r',ls="dashed",alpha=1)
         arrow4 = _Arrow3D(x[-2:],y[-2:],z[-2:],mutation_scale=20,lw=1, arrowstyle="-|>", color="r")
         self.ax.add_artist(arrow4)
 
         handles = [ 
             mlines.Line2D([], [], color='r',linestyle='solid', markersize=12, label='rotation axis direction'),
-            mlines.Line2D([], [], color='r',linestyle='dotted', markersize=12, label=r'rotation direction $\theta$'),
-            mlines.Line2D([], [], color='r',linestyle='dashed', markersize=15, label='image geometry'),
-            self.ax.scatter3D(*vox0, marker='x', alpha=1,color='r',lw=1,s=50, label='data origin (voxel 0)')
+            mlines.Line2D([], [], color='r',linestyle='dotted', markersize=15, label='image geometry'),
+            self.ax.scatter3D(*vox0, marker='x', alpha=1,color='r',lw=1,s=50, label='data origin (voxel 0)'),
+            mlines.Line2D([], [], color='r',linestyle='dashed', markersize=12, label=r'rotation direction $\theta$')
         ]
 
         for x in handles:

--- a/Wrappers/Python/cil/utilities/display.py
+++ b/Wrappers/Python/cil/utilities/display.py
@@ -584,7 +584,7 @@ class _ShowGeometry(object):
                 y_data = float(s[1]) + ro[1], float(e[1]) + ro[1]
                 z_data = float(s[2]) + ro[2], float(e[2]) + ro[2]
 
-                self.ax.plot3D(x_data,y_data,z_data, color="r",ls='dotted',alpha=0.8)
+                self.ax.plot3D(x_data,y_data,z_data, color="r",ls='dashed',alpha=0.8)
 
                 if count == 0:
                     vox0=(x_data[0],y_data[0],z_data[0])
@@ -594,7 +594,7 @@ class _ShowGeometry(object):
             x = [self.image_geometry.get_min_x(), self.image_geometry.get_max_x()]
             y = [self.image_geometry.get_min_y(), self.image_geometry.get_max_y()]
             vertex = np.array([(x[0],y[0],0),(x[0],y[1],0),(x[1],y[1],0),(x[1],y[0],0)]) + ro
-            self.ax.plot3D(*zip(*vertex, vertex[0]), color='r',ls='dotted',alpha=1)
+            self.ax.plot3D(*zip(*vertex, vertex[0]), color='r',ls='dashed',alpha=1)
             vox0=vertex[0]
             rotation_matrix = np.eye(3)
 
@@ -613,14 +613,14 @@ class _ShowGeometry(object):
             y[i] = float(point_rot[1] + ro[1])
             z[i] = float(point_rot[2] + ro[2])
 
-        self.ax.plot3D(x,y,z, color='r',ls="dashed",alpha=1)
+        self.ax.plot3D(x,y,z, color='r',ls="dotted",alpha=1)
         arrow4 = _Arrow3D(x[-2:],y[-2:],z[-2:],mutation_scale=20,lw=1, arrowstyle="-|>", color="r")
         self.ax.add_artist(arrow4)
 
         handles = [ 
             mlines.Line2D([], [], color='r',linestyle='solid', markersize=12, label='rotation axis direction'),
-            mlines.Line2D([], [], color='r',linestyle='dashed', markersize=12, label=r'rotation direction $\theta$'),
-            mlines.Line2D([], [], color='r',linestyle='dotted', markersize=15, label='image geometry'),
+            mlines.Line2D([], [], color='r',linestyle='dotted', markersize=12, label=r'rotation direction $\theta$'),
+            mlines.Line2D([], [], color='r',linestyle='dashed', markersize=15, label='image geometry'),
             self.ax.scatter3D(*vox0, marker='x', alpha=1,color='r',lw=1,s=50, label='data origin (voxel 0)')
         ]
 

--- a/Wrappers/Python/cil/utilities/display.py
+++ b/Wrappers/Python/cil/utilities/display.py
@@ -388,7 +388,7 @@ class _ShowGeometry(object):
         self.handles = []
         self.labels = []
 
-    def draw(self, elev=35, azim=35, view_distance=10, grid=False, figsize=(15,15), fontsize=10):
+    def draw(self, elev=35, azim=35, view_distance=10, grid=False, figsize=(10,10), fontsize=10):
 
         self.fig = plt.figure(figsize=figsize)
         self.ax = self.fig.add_subplot(111, projection='3d')
@@ -399,13 +399,16 @@ class _ShowGeometry(object):
 
 
         self.display_world()
-        self.display_detector()
-        self.display_object()
 
         if self.acquisition_geometry.geom_type == 'cone':
             self.display_source()
         else:
             self.display_ray()
+
+        self.display_object()
+
+        self.display_detector()
+
 
         if grid is False: 
             self.ax.set_axis_off()
@@ -417,10 +420,17 @@ class _ShowGeometry(object):
         world_limits = self.ax.get_w_lims()
         self.ax.set_box_aspect((world_limits[1]-world_limits[0],world_limits[3]-world_limits[2],world_limits[5]-world_limits[4]))
 
+        l = self.ax.plot(np.NaN, np.NaN, '-', color='none', label='')[0]
+
+        for i in range(3):
+            self.handles.insert(2,l)
+            self.labels.insert(2,'')   
+    
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
-            self.ax.legend(self.handles, self.labels, loc='upper left', bbox_to_anchor= (0, 1), ncol=1,
+            self.ax.legend(self.handles, self.labels, loc='upper left', bbox_to_anchor= (0, 1), ncol=3,
                         borderaxespad=0, frameon=False,fontsize=self.text_options.get('fontsize'))
+
 
         plt.tight_layout()
 
@@ -626,14 +636,12 @@ class _ShowGeometry(object):
         for i in range(len(det)):
             self.ax.plot3D(*zip(so,det[i]), color='#D4BD72',ls="dashed",alpha=0.4)
         
-        handles = [
-            self.ax.plot3D(*zip(so,self.acquisition_geometry.config.system.detector.position), color='#D4BD72',ls="solid",alpha=1)[0],
-            self.ax.scatter3D(*so, marker='*', alpha=1,color='#D4BD72',lw=1, label='source position', s=100)
-        ]
+        self.ax.plot3D(*zip(so,self.acquisition_geometry.config.system.detector.position), color='#D4BD72',ls="solid",alpha=1)[0],
 
-        for x in handles:
-            self.handles.append(x)
-            self.labels.append(x.get_label())
+        h0 = self.ax.scatter3D(*so, marker='*', alpha=1,color='#D4BD72',lw=1, label='source position', s=100)
+
+        self.handles.append(h0)
+        self.labels.append(h0.get_label())
 
     def display_ray(self):
 
@@ -656,7 +664,7 @@ class _ShowGeometry(object):
         self.labels.append(h0.get_label())
 
 #%%
-def show_geometry(acquisition_geometry, image_geometry=None, elevation=20, azimuthal=-35, view_distance=10, grid=False):
+def show_geometry(acquisition_geometry, image_geometry=None, elevation=20, azimuthal=-35, view_distance=10, grid=False, figsize=(10,10), fontsize=10):
     '''
     Displays a schematic of the acquisition geometry
     for 2D geometries elevation and azimuthal cannot be changed
@@ -671,12 +679,17 @@ def show_geometry(acquisition_geometry, image_geometry=None, elevation=20, azimu
     :type azimuthal: float, default=-35  
     :view_distance: Camera view distance
     :type view_distance: float, default=10  
-    :grid: Show figire axis
-    :type grid: boolean, default=False     
+    :grid: Show figure axis
+    :type grid: boolean, default=False
+    :figsize: Set figure size (inches)
+    :type figsize: tuple (x, y), default (10,10)    
+    :type grid: boolean, default=False
+    :fontsize: Set fontsize
+    :type fontsize: int 
     '''
     if acquisition_geometry.dimension == '2D':
         elevation = 90
         azimuthal = 0
 
     display = _ShowGeometry(acquisition_geometry, image_geometry)
-    display.draw(elev=elevation, azim=azimuthal, view_distance=view_distance, grid=grid)
+    display.draw(elev=elevation, azim=azimuthal, view_distance=view_distance, grid=grid, figsize=(10,10), fontsize=10)

--- a/Wrappers/Python/cil/utilities/display.py
+++ b/Wrappers/Python/cil/utilities/display.py
@@ -419,7 +419,7 @@ class _ShowGeometry(object):
 
         plt.tight_layout()
 
-        plt.draw()
+        plt.show()
 
     def display_world(self):
 

--- a/Wrappers/Python/cil/utilities/display.py
+++ b/Wrappers/Python/cil/utilities/display.py
@@ -20,6 +20,7 @@
 from cil.framework import AcquisitionGeometry, ImageGeometry, AcquisitionData, ImageData, DataContainer, BlockDataContainer
 import numpy as np
 from itertools import product, combinations
+import warnings
 
 from mpl_toolkits import mplot3d
 import matplotlib.lines as mlines
@@ -343,7 +344,7 @@ class _Arrow3D(FancyArrowPatch):
 
     def draw(self, renderer):
         xs3d, ys3d, zs3d = self._verts3d
-        xs, ys, zs = proj3d.proj_transform(xs3d, ys3d, zs3d, renderer.M)
+        xs, ys, zs = proj3d.proj_transform(xs3d, ys3d, zs3d, self.axes.M)
         self.set_positions((xs[0], ys[0]), (xs[1], ys[1]))
         FancyArrowPatch.draw(self, renderer)
 
@@ -414,8 +415,10 @@ class _ShowGeometry(object):
         world_limits = self.ax.get_w_lims()
         self.ax.set_box_aspect((world_limits[1]-world_limits[0],world_limits[3]-world_limits[2],world_limits[5]-world_limits[4]))
 
-        self.ax.legend(self.handles, self.labels, loc='upper left', bbox_to_anchor= (0, 1), ncol=1,
-                borderaxespad=0, frameon=False,fontsize=self.text_options.get('fontsize'))
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            self.ax.legend(self.handles, self.labels, loc='upper left', bbox_to_anchor= (0, 1), ncol=1,
+                        borderaxespad=0, frameon=False,fontsize=self.text_options.get('fontsize'))
 
         plt.tight_layout()
 


### PR DESCRIPTION
Used to display cone/parallel 2D/3D geometry as:

```python
from utilities.display import show_geometry
show_geometry(ag)
```
for 3D views the camera position can be set by the user with `azimuthal` `elevation` and `view_distance`

example geometries:

![image](https://user-images.githubusercontent.com/47746591/116582448-49a2b100-a90d-11eb-825c-e397b218ef99.png)

![image](https://user-images.githubusercontent.com/47746591/116582520-5f17db00-a90d-11eb-90f8-4f31c5877a18.png)

![image](https://user-images.githubusercontent.com/47746591/116582565-69d27000-a90d-11eb-9ae6-98ffadac599a.png)

![image](https://user-images.githubusercontent.com/47746591/116582598-722aab00-a90d-11eb-84fa-71f100c50439.png)

